### PR TITLE
ddl: support constraint in create table.

### DIFF
--- a/ddl/constraint.go
+++ b/ddl/constraint.go
@@ -1,0 +1,79 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/format"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+)
+
+func allocateConstraintID(tblInfo *model.TableInfo) int64 {
+	tblInfo.MaxConstraintID++
+	return tblInfo.MaxConstraintID
+}
+
+func buildConstraintInfo(tblInfo *model.TableInfo, dependedCols []model.CIStr, constr *ast.Constraint, state model.SchemaState) (*model.ConstraintInfo, error) {
+	constraintName := model.NewCIStr(constr.Name)
+	if err := checkTooLongConstraint(constraintName); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Restore check constraint expression to string.
+	var sb strings.Builder
+	restoreFlags := format.RestoreStringSingleQuotes | format.RestoreKeyWordLowercase | format.RestoreNameBackQuotes |
+		format.RestoreSpacesAroundBinaryOperation
+	restoreCtx := format.NewRestoreCtx(restoreFlags, &sb)
+
+	sb.Reset()
+	err := constr.Expr.Restore(restoreCtx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Create constraint info.
+	constraintInfo := &model.ConstraintInfo{
+		Name:           constraintName,
+		Table:          tblInfo.Name,
+		ConstraintCols: dependedCols,
+		ExprString:     sb.String(),
+		Enforced:       constr.Enforced,
+		InColumn:       constr.InColumn,
+		State:          state,
+	}
+
+	return constraintInfo, nil
+}
+
+func checkTooLongConstraint(constr model.CIStr) error {
+	if len(constr.L) > mysql.MaxConstraintIdentifierLen {
+		return ErrTooLongIdent.GenWithStackByArgs(constr)
+	}
+	return nil
+}
+
+// findDependedColsMapInExpr returns a set of string, which indicates
+// the names of the columns that are depended by exprNode.
+func findDependedColsMapInExpr(expr ast.ExprNode) map[string]struct{} {
+	colNames := findColumnNamesInExpr(expr)
+	colsMap := make(map[string]struct{}, len(colNames))
+	for _, depCol := range colNames {
+		colsMap[depCol.Name.L] = struct{}{}
+	}
+	return colsMap
+}

--- a/ddl/constraint_test.go
+++ b/ddl/constraint_test.go
@@ -1,0 +1,127 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+var _ = Suite(&testCheckConstraintSuite{&testDBSuite{}})
+
+type testCheckConstraintSuite struct{ *testDBSuite }
+
+func (s *testSequenceSuite) TestCreateTableWithCheckConstraints(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use test")
+	s.tk.MustExec("drop table if exists t")
+
+	// Test column-type check constraint.
+	s.tk.MustExec("create table t(a int not null check(a>0))")
+	constraintTable := testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 1)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 1)
+	constrs := constraintTable.Meta().Constraints
+	c.Assert(constrs[0].ID, Equals, int64(1))
+	c.Assert(constrs[0].InColumn, Equals, true)
+	c.Assert(constrs[0].Enforced, Equals, true)
+	c.Assert(constrs[0].Table.L, Equals, "t")
+	c.Assert(constrs[0].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[0].ConstraintCols), Equals, 1)
+	c.Assert(constrs[0].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("t_chk_1"))
+	c.Assert(constrs[0].ExprString, Equals, "`a` > 0")
+
+	s.tk.MustExec("drop table t")
+	s.tk.MustExec("create table t(a bigint key constraint my_constr check(a<10), b int constraint check(b > 1) not enforced)")
+	constraintTable = testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 2)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 2)
+	constrs = constraintTable.Meta().Constraints
+	c.Assert(constrs[0].ID, Equals, int64(1))
+	c.Assert(constrs[0].InColumn, Equals, true)
+	c.Assert(constrs[0].Enforced, Equals, true)
+	c.Assert(constrs[0].Table.L, Equals, "t")
+	c.Assert(constrs[0].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[0].ConstraintCols), Equals, 1)
+	c.Assert(constrs[0].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("my_constr"))
+	c.Assert(constrs[0].ExprString, Equals, "`a` < 10")
+
+	c.Assert(constrs[1].ID, Equals, int64(2))
+	c.Assert(constrs[1].InColumn, Equals, true)
+	c.Assert(constrs[1].Enforced, Equals, false)
+	c.Assert(constrs[1].Table.L, Equals, "t")
+	c.Assert(constrs[1].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[1].ConstraintCols), Equals, 1)
+	c.Assert(constrs[1].ConstraintCols[0], Equals, model.NewCIStr("b"))
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("t_chk_1"))
+	c.Assert(constrs[1].ExprString, Equals, "`b` > 1")
+
+	// Test table-type check constraint.
+	s.tk.MustExec("drop table t")
+	s.tk.MustExec("create table t(a int constraint check(a > 1) not enforced, constraint my_constr check(a < 10))")
+	constraintTable = testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 1)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 2)
+	constrs = constraintTable.Meta().Constraints
+	// table-type check constraint.
+	c.Assert(constrs[0].ID, Equals, int64(1))
+	c.Assert(constrs[0].InColumn, Equals, false)
+	c.Assert(constrs[0].Enforced, Equals, true)
+	c.Assert(constrs[0].Table.L, Equals, "t")
+	c.Assert(constrs[0].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[0].ConstraintCols), Equals, 1)
+	c.Assert(constrs[0].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("my_constr"))
+	c.Assert(constrs[0].ExprString, Equals, "`a` < 10")
+
+	// column-type check constraint.
+	c.Assert(constrs[1].ID, Equals, int64(2))
+	c.Assert(constrs[1].InColumn, Equals, true)
+	c.Assert(constrs[1].Enforced, Equals, false)
+	c.Assert(constrs[1].Table.L, Equals, "t")
+	c.Assert(constrs[1].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[1].ConstraintCols), Equals, 1)
+	c.Assert(constrs[1].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("t_chk_1"))
+	c.Assert(constrs[1].ExprString, Equals, "`a` > 1")
+
+	// Test column-type check constraint fail on dependency.
+	s.tk.MustExec("drop table t")
+	_, err := s.tk.Exec("create table t(a int not null check(b>0))")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3813]Column check constraint 't_chk_1' references other column.")
+
+	_, err = s.tk.Exec("create table t(a int not null check(b>a))")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3813]Column check constraint 't_chk_1' references other column.")
+
+	_, err = s.tk.Exec("create table t(a int not null check(a>0), b int, constraint check(c>b))")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3820]Check constraint 't_chk_1' refers to non-existing column 'c'.")
+
+	s.tk.MustExec("create table t(a int not null check(a>0), b int, constraint check(a>b))")
+	s.tk.MustExec("drop table t")
+
+	s.tk.MustExec("create table t(a int not null check(a > '12345'))")
+	s.tk.MustExec("drop table t")
+
+	s.tk.MustExec("create table t(a int not null primary key check(a > '12345'))")
+	s.tk.MustExec("drop table t")
+
+	s.tk.MustExec("create table t(a varchar(10) not null primary key check(a > '12345'))")
+	s.tk.MustExec("drop table t")
+}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -607,6 +607,18 @@ func columnDefToCol(ctx sessionctx.Context, offset int, colDef *ast.ColumnDef, o
 				}
 			case ast.ColumnOptionFulltext:
 				ctx.GetSessionVars().StmtCtx.AppendWarning(ErrTableCantHandleFt)
+			case ast.ColumnOptionCheck:
+				// Check the column CHECK constraint dependency lazily, after fill all the name.
+				// Extract column constraint from column option.
+				constraint := &ast.Constraint{
+					Tp:           ast.ConstraintCheck,
+					Expr:         v.Expr,
+					Enforced:     v.Enforced,
+					Name:         v.ConstraintName,
+					InColumn:     true,
+					InColumnName: colDef.Name.Name.O,
+				}
+				constraints = append(constraints, constraint)
 			}
 		}
 	}
@@ -1077,6 +1089,26 @@ func checkDuplicateConstraint(namesMap map[string]bool, name string, foreign boo
 	return nil
 }
 
+func setEmptyCheckConstraintName(tableLowerName string, namesMap map[string]bool, constrs []*ast.Constraint) {
+	cnt := 1
+	constraintPrefix := tableLowerName + "_chk_"
+	for _, constr := range constrs {
+		if constr.Name == "" {
+			constrName := fmt.Sprintf("%s%d", constraintPrefix, cnt)
+			for {
+				// loop until find constrName that haven't been used.
+				if !namesMap[constrName] {
+					namesMap[constrName] = true
+					break
+				}
+				cnt++
+				constrName = fmt.Sprintf("%s%d", constraintPrefix, cnt)
+			}
+			constr.Name = constrName
+		}
+	}
+}
+
 func setEmptyConstraintName(namesMap map[string]bool, constr *ast.Constraint, foreign bool) {
 	if constr.Name == "" && len(constr.Keys) > 0 {
 		colName := constr.Keys[0].Column.Name.L
@@ -1100,7 +1132,7 @@ func setEmptyConstraintName(namesMap map[string]bool, constr *ast.Constraint, fo
 	}
 }
 
-func checkConstraintNames(constraints []*ast.Constraint) error {
+func checkConstraintNames(tableName model.CIStr, constraints []*ast.Constraint) error {
 	constrNames := map[string]bool{}
 	fkNames := map[string]bool{}
 
@@ -1119,15 +1151,22 @@ func checkConstraintNames(constraints []*ast.Constraint) error {
 		}
 	}
 
+	checkConstraints := make([]*ast.Constraint, 0, len(constraints))
 	// Set empty constraint names.
 	for _, constr := range constraints {
+		if constr.Tp == ast.ConstraintCheck {
+			checkConstraints = append(checkConstraints, constr)
+		}
 		if constr.Tp == ast.ConstraintForeignKey {
 			setEmptyConstraintName(fkNames, constr, true)
 		} else {
 			setEmptyConstraintName(constrNames, constr, false)
 		}
 	}
-
+	// Set check constraint name under its order.
+	if len(checkConstraints) > 0 {
+		setEmptyCheckConstraintName(tableName.L, constrNames, checkConstraints)
+	}
 	return nil
 }
 
@@ -1263,9 +1302,12 @@ func buildTableInfo(
 		Charset: charset,
 		Collate: collate,
 	}
+	// existedColsMap is used to check existence of the depended column.
+	existedColsMap := make(map[string]struct{}, len(cols))
 	for _, v := range cols {
 		v.ID = allocateColumnID(tbInfo)
 		tbInfo.Columns = append(tbInfo.Columns, v.ToInfo())
+		existedColsMap[v.Name.L] = struct{}{}
 	}
 	for _, constr := range constraints {
 		if constr.Tp == ast.ConstraintForeignKey {
@@ -1309,6 +1351,45 @@ func buildTableInfo(
 			sc.AppendWarning(ErrTableCantHandleFt)
 			continue
 		}
+
+		if constr.Tp == ast.ConstraintCheck {
+			// Since column check constraint dependency has been done in colDefToCol.
+			// Here do the table check constraint dependency check, table constraint
+			// can only refer the columns in defined columns of the table.
+			// Refer: https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html
+			var dependedCols []model.CIStr
+			if !constr.InColumn {
+				dependedColsMap := findDependedColsMapInExpr(constr.Expr)
+				dependedCols = make([]model.CIStr, 0, len(dependedColsMap))
+				for k := range dependedColsMap {
+					if _, ok := existedColsMap[k]; !ok {
+						// The table constraint depended on a non-existed column.
+						return nil, ErrTableCheckConstraintReferUnknown.GenWithStackByArgs(constr.Name, k)
+					}
+					dependedCols = append(dependedCols, model.NewCIStr(k))
+				}
+			} else {
+				// Check the column-type constraint dependency.
+				dependedColsMap := findDependedColsMapInExpr(constr.Expr)
+				if len(dependedColsMap) != 1 {
+					return nil, ErrColumnCheckConstraintReferOther.GenWithStackByArgs(constr.Name)
+				}
+				if _, ok := dependedColsMap[constr.InColumnName]; !ok {
+					return nil, ErrColumnCheckConstraintReferOther.GenWithStackByArgs(constr.Name)
+				}
+				dependedCols = []model.CIStr{model.NewCIStr(constr.InColumnName)}
+			}
+
+			// build constraint meta info.
+			constraintInfo, err := buildConstraintInfo(tbInfo, dependedCols, constr, model.StatePublic)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			constraintInfo.ID = allocateConstraintID(tbInfo)
+			tbInfo.Constraints = append(tbInfo.Constraints, constraintInfo)
+			continue
+		}
+
 		// build index info.
 		idxInfo, err := buildIndexInfo(tbInfo, model.NewCIStr(constr.Name), constr.Keys, model.StatePublic)
 		if err != nil {
@@ -1501,7 +1582,7 @@ func buildTableInfoWithStmt(ctx sessionctx.Context, s *ast.CreateTableStmt, dbCh
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	err = checkConstraintNames(newConstraints)
+	err = checkConstraintNames(s.Table.Name, newConstraints)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/ddl/error.go
+++ b/ddl/error.go
@@ -202,4 +202,8 @@ var (
 	ErrColumnTypeUnsupportedNextValue = terror.ClassDDL.New(mysql.ErrColumnTypeUnsupportedNextValue, mysql.MySQLErrName[mysql.ErrColumnTypeUnsupportedNextValue])
 	// ErrUnsupportedExpressionIndex is returned when create an expression index without allow-expression-index.
 	ErrUnsupportedExpressionIndex = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "creating expression index without allow-expression-index in config"))
+	// ErrColumnCheckConstraintReferOther is returned when create column check constraint referring other column.
+	ErrColumnCheckConstraintReferOther = terror.ClassDDL.New(mysql.ErrColumnCheckConstraintReferOther, mysql.MySQLErrName[mysql.ErrColumnCheckConstraintReferOther])
+	// ErrTableCheckConstraintReferUnknown is returned when create table check constraint referring non-existing column.
+	ErrTableCheckConstraintReferUnknown = terror.ClassDDL.New(mysql.ErrTableCheckConstraintReferUnknown, mysql.MySQLErrName[mysql.ErrTableCheckConstraintReferUnknown])
 )

--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -944,6 +944,8 @@ const (
 	ErrFunctionalIndexOnField                                       = 3762
 	ErrFKIncompatibleColumns                                        = 3780
 	ErrFunctionalIndexRowValueIsNotAllowed                          = 3800
+	ErrColumnCheckConstraintReferOther                              = 3813
+	ErrTableCheckConstraintReferUnknown                             = 3820
 	ErrDependentByFunctionalIndex                                   = 3837
 	ErrInvalidJSONValueForFuncIndex                                 = 3903
 	ErrJSONValueOutOfRangeForFuncIndex                              = 3904

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -941,6 +941,8 @@ var MySQLErrName = map[uint16]string{
 	ErrFunctionalIndexOnField:                                "Functional index on a column is not supported. Consider using a regular index instead",
 	ErrFKIncompatibleColumns:                                 "Referencing column '%s' in foreign key constraint '%s' are incompatible",
 	ErrFunctionalIndexRowValueIsNotAllowed:                   "Expression of functional index '%s' cannot refer to a row value",
+	ErrColumnCheckConstraintReferOther:                       "Column check constraint '%s' references other column.",
+	ErrTableCheckConstraintReferUnknown:                      "Check constraint '%s' refers to non-existing column '%s'.",
 	ErrDependentByFunctionalIndex:                            "Column '%s' has a functional index dependency and cannot be dropped or renamed",
 	ErrInvalidJSONValueForFuncIndex:                          "Invalid JSON value for CAST for functional index '%s'",
 	ErrJSONValueOutOfRangeForFuncIndex:                       "Out of range JSON value for CAST for functional index '%s'",

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20200420075417-e0c6e8842f22
 	github.com/pingcap/log v0.0.0-20200511115504-543df19646ad
-	github.com/pingcap/parser v0.0.0-20200509042029-4c8a0b68bbb3
+	github.com/pingcap/parser v0.0.0-20200602044958-becdf8cc583d
 	github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2
 	github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1
 	github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incompatible
@@ -69,6 +69,7 @@ require (
 	google.golang.org/grpc v1.25.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/appleboy/gin-jwt/v2 v2.6.3/go.mod h1:MfPYA4ogzvOcVkRwAxT7quHOtQmVKDpTwxyUrC2DNw0=
 github.com/appleboy/gofight/v2 v2.1.2/go.mod h1:frW+U1QZEdDgixycTj4CygQ48yLTUhplt43+Wczp3rw=
-github.com/bb7133/parser v0.0.0-20200509042029-4c8a0b68bbb3 h1:fdg8VSXfDZRFr/sDPNz61WJwtgNFduxJYG6o4h4WuYk=
-github.com/bb7133/parser v0.0.0-20200509042029-4c8a0b68bbb3/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -286,8 +284,8 @@ github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfE
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad h1:SveG82rmu/GFxYanffxsSF503SiQV+2JLnWEiGiF+Tc=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20200509042029-4c8a0b68bbb3 h1:vsczziSl0e3e2XztaVmyTWSzOgnLAxGkDVDcEmdvhI0=
-github.com/pingcap/parser v0.0.0-20200509042029-4c8a0b68bbb3/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
+github.com/pingcap/parser v0.0.0-20200602044958-becdf8cc583d h1:NsvWIRtiuEq6ciTvn4tnEyvvV1ZIhCU9eTQXbhbOQWM=
+github.com/pingcap/parser v0.0.0-20200602044958-becdf8cc583d/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2 h1:JTzYYukREvxVSKW/ncrzNjFitd8snoQ/Xz32pw8i+s8=
 github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2/go.mod h1:s+utZtXDznOiL24VK0qGmtoHjjXNsscJx3m1n8cC56s=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
@@ -416,8 +414,6 @@ go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.12.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
-go.uber.org/zap v1.14.1 h1:nYDKopTbvAPq/NrUVZwT15y2lpROBiLLyoRTbXOYWOo=
-go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.15.0 h1:ZZCA22JRF2gQE5FoNmhmrf7jeJJ2uhqDUNRYKm8dvmM=
 go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -567,6 +563,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
+honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -148,7 +148,7 @@ func (p *UserPrivileges) GetAuthWithoutVerification(user, host string) (u string
 	return
 }
 
-// CheckAccountLock return if the account has been locked.
+// CheckAccountLocked return if the account has been locked.
 func (p *UserPrivileges) CheckAccountLocked(ctx sessionctx.Context, user, host string) bool {
 	if SkipWithGrant {
 		return false
@@ -183,6 +183,7 @@ func (p *UserPrivileges) CheckAccountLocked(ctx sessionctx.Context, user, host s
 	return false
 }
 
+// IncFailTimer ...
 func (p *UserPrivileges) IncFailTimer(ctx sessionctx.Context, user, host string) {
 	if SkipWithGrant {
 		return

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -285,6 +285,7 @@ const (
 		name char(100) NOT NULL
 	);`
 
+	// CreateLoginBlackList stores the list of disabled login role.
 	CreateLoginBlackList = `CREATE TABLE IF NOT EXISTS mysql.login_blacklist (
 		HOST char(60) COLLATE utf8_bin NOT NULL DEFAULT '',
 		USER char(32) COLLATE utf8_bin NOT NULL DEFAULT '',

--- a/table/constraint.go
+++ b/table/constraint.go
@@ -1,0 +1,18 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+// Constraint provides meta and map dependency describing a table constraint.
+type Constraint struct {
+}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -51,17 +51,19 @@ import (
 type TableCommon struct {
 	tableID int64
 	// physicalTableID is a unique int64 to identify a physical table.
-	physicalTableID int64
-	Columns         []*table.Column
-	PublicColumns   []*table.Column
-	VisibleColumns  []*table.Column
-	HiddenColumns   []*table.Column
-	WritableColumns []*table.Column
-	writableIndices []table.Index
-	indices         []table.Index
-	meta            *model.TableInfo
-	allocs          autoid.Allocators
-	sequence        *sequenceCommon
+	physicalTableID     int64
+	Columns             []*table.Column
+	PublicColumns       []*table.Column
+	VisibleColumns      []*table.Column
+	HiddenColumns       []*table.Column
+	WritableColumns     []*table.Column
+	PublicConstraints   []table.Constraint
+	WritableConstraints []table.Constraint
+	writableIndices     []table.Index
+	indices             []table.Index
+	meta                *model.TableInfo
+	allocs              autoid.Allocators
+	sequence            *sequenceCommon
 
 	// recordPrefix and indexPrefix are generated using physicalTableID.
 	recordPrefix kv.Key


### PR DESCRIPTION
Signed-off-by: Arenatlx <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Close issue: https://github.com/pingcap/tidb/issues/17406
Problem Summary:
Implement check constraints in TiDB
For example:
```
create table t(a int constraint haha check(a>1), constraint hehe check(a<10));
```
the column-level `haha` check constraint and table-level `hehe` constraint now can be checked and attach-stored in tableInfo.

### What is changed and how it works?

What's Changed:
1: modify tableInfo add constraint field.
2: handle the constraint from parser, do dependency check in ddl, and store it.
3: do some test about it


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- implement the check constraints in create table