### PR TITLE
ddl: support alter table add/drop/alter check constraint

### DIFF
--- a/ddl/constraint.go
+++ b/ddl/constraint.go
@@ -14,14 +14,250 @@
 package ddl
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/format"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/meta"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/util/sqlexec"
 )
+
+func (w *worker) onAddCheckConstraint(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error) {
+	// Handle the rolling back job.
+	if job.IsRollingback() {
+		ver, err = onDropCheckConstraint(t, job)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
+		return ver, nil
+	}
+
+	failpoint.Inject("errorBeforeDecodeArgs", func(val failpoint.Value) {
+		if val.(bool) {
+			failpoint.Return(ver, errors.New("occur an error before decode args"))
+		}
+	})
+
+	dbInfo, tblInfo, constraintInfoInMeta, constraintInfoInJob, err := checkAddCheckConstraint(t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	if constraintInfoInMeta == nil {
+		// It's first time to run add constraint job, so there is no constraint info in meta.
+		// Use the raw constraint info from job directly and modify table info here.
+		constraintInfoInJob.ID = allocateConstraintID(tblInfo)
+		// Reset constraint name according to real-time constraints name at this point.
+		constrNames := map[string]bool{}
+		for _, constr := range tblInfo.Constraints {
+			constrNames[constr.Name.L] = true
+		}
+		setNameForConstraintInfo(tblInfo.Name.L, constrNames, []*model.ConstraintInfo{constraintInfoInJob})
+		// Double check the constraint dependency.
+		existedColsMap := make(map[string]struct{})
+		cols := tblInfo.Columns
+		for _, v := range cols {
+			if v.State == model.StatePublic {
+				existedColsMap[v.Name.L] = struct{}{}
+			}
+		}
+		dependedCols := constraintInfoInJob.ConstraintCols
+		for _, k := range dependedCols {
+			if _, ok := existedColsMap[k.L]; !ok {
+				// The table constraint depended on a non-existed column.
+				return ver, ErrTableCheckConstraintReferUnknown.GenWithStackByArgs(constraintInfoInJob.Name, k)
+			}
+		}
+
+		tblInfo.Constraints = append(tblInfo.Constraints, constraintInfoInJob)
+		constraintInfoInMeta = constraintInfoInJob
+	}
+
+	originalState := constraintInfoInMeta.State
+	switch constraintInfoInMeta.State {
+	case model.StateNone:
+		// none -> delete only
+		job.SchemaState = model.StateWriteOnly
+		constraintInfoInMeta.State = model.StateWriteOnly
+		ver, err = updateVersionAndTableInfoWithCheck(t, job, tblInfo, originalState != constraintInfoInMeta.State)
+	case model.StateWriteOnly:
+		// write only -> public
+		err = w.addTableCheckConstraint(dbInfo, tblInfo, constraintInfoInMeta, job)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
+		constraintInfoInMeta.State = model.StatePublic
+		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != constraintInfoInMeta.State)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
+
+		// Finish this job.
+		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
+	default:
+		err = ErrInvalidDDLState.GenWithStackByArgs("constraint", constraintInfoInMeta.State)
+	}
+
+	return ver, errors.Trace(err)
+}
+
+// onDropCheckConstraint can be called from two case:
+// 1: rollback in add constraint.(in rollback function the job.args will be changed)
+// 2: user drop constraint ddl.
+func onDropCheckConstraint(t *meta.Meta, job *model.Job) (ver int64, _ error) {
+	tblInfo, constraintInfo, err := checkDropCheckConstraint(t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+
+	originalState := constraintInfo.State
+	switch constraintInfo.State {
+	case model.StatePublic:
+		// public -> write only
+		job.SchemaState = model.StateWriteOnly
+		constraintInfo.State = model.StateWriteOnly
+		ver, err = updateVersionAndTableInfoWithCheck(t, job, tblInfo, originalState != constraintInfo.State)
+	case model.StateWriteOnly:
+		// write only -> None
+		// write only state constraint will still take effect to check the newly inserted data.
+		// So the depended column shouldn't be dropped even in this intermediate state.
+		constraintInfo.State = model.StateNone
+		// remove the constraint from tableInfo.
+		for i, constr := range tblInfo.Constraints {
+			if constr.Name.L == constraintInfo.Name.L {
+				tblInfo.Constraints = append(tblInfo.Constraints[0:i], tblInfo.Constraints[i+1:]...)
+			}
+		}
+		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != constraintInfo.State)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
+
+		// Finish this job.
+		if job.IsRollingback() {
+			job.FinishTableJob(model.JobStateRollbackDone, model.StateNone, ver, tblInfo)
+		} else {
+			job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
+		}
+	default:
+		err = errInvalidDDLJob.GenWithStackByArgs("constraint", tblInfo.State)
+	}
+	return ver, errors.Trace(err)
+}
+
+func (w *worker) onAlterCheckConstraint(t *meta.Meta, job *model.Job) (ver int64, _ error) {
+	dbInfo, tblInfo, constraintInfo, enforced, err := checkAlterCheckConstraint(t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+
+	// enforced will fetch table data and check the constraint.
+	if constraintInfo.Enforced != enforced && enforced {
+		err = w.addTableCheckConstraint(dbInfo, tblInfo, constraintInfo, job)
+		if err != nil {
+			// check constraint error will cancel the job, job state has been changed
+			// to cancelled in addTableCheckConstraint.
+			return ver, errors.Trace(err)
+		}
+	}
+	constraintInfo.Enforced = enforced
+	ver, err = updateVersionAndTableInfoWithCheck(t, job, tblInfo, true)
+	if err != nil {
+		// update version and tableInfo error will cause retry.
+		return ver, errors.Trace(err)
+	}
+
+	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
+	return ver, nil
+}
+
+func checkDropCheckConstraint(t *meta.Meta, job *model.Job) (*model.TableInfo, *model.ConstraintInfo, error) {
+	schemaID := job.SchemaID
+	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, schemaID)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	var constrName model.CIStr
+	err = job.DecodeArgs(&constrName)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return nil, nil, errors.Trace(err)
+	}
+
+	// do the double-check with constraint existence.
+	constraintInfo := tblInfo.FindConstraintInfoByName(constrName.L)
+	if constraintInfo == nil {
+		job.State = model.JobStateCancelled
+		return nil, nil, ErrConstraintDoesNotExist.GenWithStackByArgs(constrName)
+	}
+	return tblInfo, constraintInfo, nil
+}
+
+func checkAddCheckConstraint(t *meta.Meta, job *model.Job) (*model.DBInfo, *model.TableInfo, *model.ConstraintInfo, *model.ConstraintInfo, error) {
+	schemaID := job.SchemaID
+	dbInfo, err := t.GetDatabase(job.SchemaID)
+	if err != nil {
+		return nil, nil, nil, nil, errors.Trace(err)
+	}
+	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, schemaID)
+	if err != nil {
+		return nil, nil, nil, nil, errors.Trace(err)
+	}
+	constraintInfo1 := &model.ConstraintInfo{}
+	err = job.DecodeArgs(constraintInfo1)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return nil, nil, nil, nil, errors.Trace(err)
+	}
+	// do the double-check with constraint existence.
+	constraintInfo2 := tblInfo.FindConstraintInfoByName(constraintInfo1.Name.L)
+	if constraintInfo2 != nil {
+		if constraintInfo2.State == model.StatePublic {
+			// We already have a column with the same column name.
+			job.State = model.JobStateCancelled
+			return nil, nil, nil, nil, infoschema.ErrColumnExists.GenWithStackByArgs(constraintInfo1.Name)
+		}
+		// if not, that means constraint was in intermediate state.
+	}
+	return dbInfo, tblInfo, constraintInfo2, constraintInfo1, nil
+}
+
+func checkAlterCheckConstraint(t *meta.Meta, job *model.Job) (*model.DBInfo, *model.TableInfo, *model.ConstraintInfo, bool, error) {
+	schemaID := job.SchemaID
+	dbInfo, err := t.GetDatabase(job.SchemaID)
+	if err != nil {
+		return nil, nil, nil, false, errors.Trace(err)
+	}
+	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, schemaID)
+	if err != nil {
+		return nil, nil, nil, false, errors.Trace(err)
+	}
+
+	var (
+		enforced   bool
+		constrName model.CIStr
+	)
+	err = job.DecodeArgs(&constrName, &enforced)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return nil, nil, nil, false, errors.Trace(err)
+	}
+
+	// do the double-check with constraint existence.
+	constraintInfo := tblInfo.FindConstraintInfoByName(constrName.L)
+	if constraintInfo == nil {
+		job.State = model.JobStateCancelled
+		return nil, nil, nil, false, ErrConstraintDoesNotExist.GenWithStackByArgs(constrName)
+	}
+	return dbInfo, tblInfo, constraintInfo, enforced, nil
+}
 
 func allocateConstraintID(tblInfo *model.TableInfo) int64 {
 	tblInfo.MaxConstraintID++
@@ -76,4 +312,53 @@ func findDependedColsMapInExpr(expr ast.ExprNode) map[string]struct{} {
 		colsMap[depCol.Name.L] = struct{}{}
 	}
 	return colsMap
+}
+
+func (w *worker) addTableCheckConstraint(dbInfo *model.DBInfo, tableInfo *model.TableInfo, constr *model.ConstraintInfo, job *model.Job) error {
+	// Get sessionctx from ddl context resource pool in ddl worker.
+	var ctx sessionctx.Context
+	ctx, err := w.sessPool.get()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer w.sessPool.put(ctx)
+
+	// If there is any row can't pass the check expression, the add constraint action will error.
+	// It's no need to construct expression node out and pull the chunk rows through it. Here we
+	// can let the check expression restored string as the filter in where clause directly.
+	// Prepare internal SQL to fetch data from physical table under .
+	sql := fmt.Sprintf("select * from `%s`.`%s` where ", dbInfo.Name.L, tableInfo.Name.L)
+	sql = sql + " not " + constr.ExprString + " limit 1"
+	fmt.Println("check sql: ", sql)
+	rows, _, err := ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(sql)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rowCount := len(rows)
+	if rowCount != 0 {
+		// If check constraint fail, the job state should be changed to canceled, otherwise it will tracked in.
+		job.State = model.JobStateCancelled
+		return ErrCheckConstraintIsViolated.GenWithStackByArgs(constr.Name.L)
+	}
+	return nil
+}
+
+func setNameForConstraintInfo(tableLowerName string, namesMap map[string]bool, infos []*model.ConstraintInfo) {
+	cnt := 1
+	constraintPrefix := tableLowerName + "_chk_"
+	for _, constrInfo := range infos {
+		if constrInfo.Name.O == "" {
+			constrName := fmt.Sprintf("%s%d", constraintPrefix, cnt)
+			for {
+				// loop until find constrName that haven't been used.
+				if !namesMap[constrName] {
+					namesMap[constrName] = true
+					break
+				}
+				cnt++
+				constrName = fmt.Sprintf("%s%d", constraintPrefix, cnt)
+			}
+			constrInfo.Name = model.NewCIStr(constrName)
+		}
+	}
 }

--- a/ddl/constraint_test.go
+++ b/ddl/constraint_test.go
@@ -14,6 +14,8 @@
 package ddl_test
 
 import (
+	"sort"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/util/testkit"
@@ -124,4 +126,198 @@ func (s *testSequenceSuite) TestCreateTableWithCheckConstraints(c *C) {
 
 	s.tk.MustExec("create table t(a varchar(10) not null primary key check(a > '12345'))")
 	s.tk.MustExec("drop table t")
+}
+
+func (s *testSequenceSuite) TestAlterTableAddCheckConstraints(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use test")
+	s.tk.MustExec("drop table if exists t")
+
+	s.tk.MustExec("create table t(a int not null check(a>0))")
+	// Add constraint with name.
+	s.tk.MustExec("alter table t add constraint haha check(a<10)")
+	constraintTable := testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 1)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 2)
+	constrs := constraintTable.Meta().Constraints
+	c.Assert(constrs[1].ID, Equals, int64(2))
+	c.Assert(constrs[1].InColumn, Equals, false)
+	c.Assert(constrs[1].Enforced, Equals, true)
+	c.Assert(constrs[1].Table.L, Equals, "t")
+	c.Assert(constrs[1].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[1].ConstraintCols), Equals, 1)
+	c.Assert(constrs[1].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("haha"))
+	c.Assert(constrs[1].ExprString, Equals, "`a` < 10")
+
+	// Add constraint without name.
+	s.tk.MustExec("alter table t add constraint check(a<11) not enforced")
+	constraintTable = testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 1)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 3)
+	constrs = constraintTable.Meta().Constraints
+	c.Assert(constrs[2].ID, Equals, int64(3))
+	c.Assert(constrs[2].InColumn, Equals, false)
+	c.Assert(constrs[2].Enforced, Equals, false)
+	c.Assert(constrs[2].Table.L, Equals, "t")
+	c.Assert(constrs[2].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[2].ConstraintCols), Equals, 1)
+	c.Assert(constrs[2].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[2].Name, Equals, model.NewCIStr("t_chk_2"))
+	c.Assert(constrs[2].ExprString, Equals, "`a` < 11")
+
+	// Add constraint with the name has already existed.
+	_, err := s.tk.Exec("alter table t add constraint haha check(a)")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[schema:3822]Duplicate check constraint name 'haha'.")
+
+	// Add constraint with the unknown column.
+	_, err = s.tk.Exec("alter table t add constraint check(b)")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3820]Check constraint 't_chk_3' refers to non-existing column 'b'.")
+
+	s.tk.MustExec("alter table t add constraint check(a*2 < a+1) not enforced")
+}
+
+func (s *testSequenceSuite) TestAlterTableDropCheckConstraints(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use test")
+	s.tk.MustExec("drop table if exists t")
+
+	s.tk.MustExec("create table t(a int not null check(a>0), b int, constraint haha check(a < b), check(a<b+1))")
+	constraintTable := testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 2)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 3)
+	constrs := constraintTable.Meta().Constraints
+
+	c.Assert(constrs[0].ID, Equals, int64(1))
+	c.Assert(constrs[0].InColumn, Equals, false)
+	c.Assert(constrs[0].Enforced, Equals, true)
+	c.Assert(constrs[0].Table.L, Equals, "t")
+	c.Assert(constrs[0].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[0].ConstraintCols), Equals, 2)
+	sort.Slice(constrs[0].ConstraintCols, func(i, j int) bool {
+		return constrs[0].ConstraintCols[i].L < constrs[0].ConstraintCols[j].L
+	})
+	c.Assert(constrs[0].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[0].ConstraintCols[1], Equals, model.NewCIStr("b"))
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("haha"))
+	c.Assert(constrs[0].ExprString, Equals, "`a` < `b`")
+
+	c.Assert(constrs[1].ID, Equals, int64(2))
+	c.Assert(constrs[1].InColumn, Equals, false)
+	c.Assert(constrs[1].Enforced, Equals, true)
+	c.Assert(constrs[1].Table.L, Equals, "t")
+	c.Assert(constrs[1].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[1].ConstraintCols), Equals, 2)
+	sort.Slice(constrs[1].ConstraintCols, func(i, j int) bool {
+		return constrs[1].ConstraintCols[i].L < constrs[1].ConstraintCols[j].L
+	})
+	c.Assert(constrs[1].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[1].ConstraintCols[1], Equals, model.NewCIStr("b"))
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("t_chk_1"))
+	c.Assert(constrs[1].ExprString, Equals, "`a` < `b` + 1")
+
+	// Column check constraint will be appended to the table constraint list.
+	// So the offset will be the last one, so is the id.
+	c.Assert(constrs[2].ID, Equals, int64(3))
+	c.Assert(constrs[2].InColumn, Equals, true)
+	c.Assert(constrs[2].Enforced, Equals, true)
+	c.Assert(constrs[2].Table.L, Equals, "t")
+	c.Assert(constrs[2].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[2].ConstraintCols), Equals, 1)
+	c.Assert(constrs[2].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[2].Name, Equals, model.NewCIStr("t_chk_2"))
+	c.Assert(constrs[2].ExprString, Equals, "`a` > 0")
+
+	// Drop a non-exist constraint
+	_, err := s.tk.Exec("alter table t drop constraint not_exist_constraint")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3940]Constraint 'not_exist_constraint' does not exist")
+
+	s.tk.MustExec("alter table t drop constraint haha")
+	constraintTable = testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 2)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 2)
+	constrs = constraintTable.Meta().Constraints
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("t_chk_1"))
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("t_chk_2"))
+
+	s.tk.MustExec("alter table t drop constraint t_chk_2")
+	constraintTable = testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 2)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 1)
+	constrs = constraintTable.Meta().Constraints
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("t_chk_1"))
+}
+
+func (s *testSequenceSuite) TestAlterTableAlterCheckConstraints(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use test")
+	s.tk.MustExec("drop table if exists t")
+
+	s.tk.MustExec("create table t(a int not null check(a>0) not enforced, b int, constraint haha check(a < b))")
+	constraintTable := testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 2)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 2)
+	constrs := constraintTable.Meta().Constraints
+
+	c.Assert(constrs[0].ID, Equals, int64(1))
+	c.Assert(constrs[0].InColumn, Equals, false)
+	c.Assert(constrs[0].Enforced, Equals, true)
+	c.Assert(constrs[0].Table.L, Equals, "t")
+	c.Assert(constrs[0].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[0].ConstraintCols), Equals, 2)
+	sort.Slice(constrs[0].ConstraintCols, func(i, j int) bool {
+		return constrs[0].ConstraintCols[i].L < constrs[0].ConstraintCols[j].L
+	})
+	c.Assert(constrs[0].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[0].ConstraintCols[1], Equals, model.NewCIStr("b"))
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("haha"))
+	c.Assert(constrs[0].ExprString, Equals, "`a` < `b`")
+
+	c.Assert(constrs[1].ID, Equals, int64(2))
+	c.Assert(constrs[1].InColumn, Equals, true)
+	c.Assert(constrs[1].Enforced, Equals, false)
+	c.Assert(constrs[1].Table.L, Equals, "t")
+	c.Assert(constrs[1].State, Equals, model.StatePublic)
+	c.Assert(len(constrs[1].ConstraintCols), Equals, 1)
+	c.Assert(constrs[1].ConstraintCols[0], Equals, model.NewCIStr("a"))
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("t_chk_1"))
+	c.Assert(constrs[1].ExprString, Equals, "`a` > 0")
+
+	// Alter constraint alter constraint with unknown name.
+	_, err := s.tk.Exec("alter table t alter constraint unkown not enforced")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3940]Constraint 'unkown' does not exist")
+
+	// Alter table alter constraint with user name.
+	s.tk.MustExec("alter table t alter constraint haha not enforced")
+	constraintTable = testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 2)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 2)
+	constrs = constraintTable.Meta().Constraints
+	c.Assert(constrs[0].Enforced, Equals, false)
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("haha"))
+	c.Assert(constrs[1].Enforced, Equals, false)
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("t_chk_1"))
+
+	// Alter table alter constraint with generated name.
+	s.tk.MustExec("alter table t alter constraint t_chk_1 enforced")
+	constraintTable = testGetTableByName(c, s.s, "test", "t")
+	c.Assert(len(constraintTable.Meta().Columns), Equals, 2)
+	c.Assert(len(constraintTable.Meta().Constraints), Equals, 2)
+	constrs = constraintTable.Meta().Constraints
+	c.Assert(constrs[0].Enforced, Equals, false)
+	c.Assert(constrs[0].Name, Equals, model.NewCIStr("haha"))
+	c.Assert(constrs[1].Enforced, Equals, true)
+	c.Assert(constrs[1].Name, Equals, model.NewCIStr("t_chk_1"))
+
+	// Alter table alter constraint will violate check.
+	// Here a=1, b=0 doesn't satisfy "a < b" constraint.
+	// Since "a<b" is not enforced, so the insert will success.
+	s.tk.MustExec("insert into t values(1, 0)")
+	_, err = s.tk.Exec("alter table t alter constraint haha enforced")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3819]Check constraint 'haha' is violated")
 }

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -655,6 +655,12 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = onCreateSequence(d, t, job)
 	case model.ActionAlterIndexVisibility:
 		ver, err = onAlterIndexVisibility(t, job)
+	case model.ActionAddCheckConstraint:
+		ver, err = w.onAddCheckConstraint(d, t, job)
+	case model.ActionDropCheckConstraint:
+		ver, err = onDropCheckConstraint(t, job)
+	case model.ActionAlterCheckConstraint:
+		ver, err = w.onAlterCheckConstraint(t, job)
 	default:
 		// Invalid job, cancel it.
 		job.State = model.JobStateCancelled

--- a/ddl/error.go
+++ b/ddl/error.go
@@ -206,4 +206,8 @@ var (
 	ErrColumnCheckConstraintReferOther = terror.ClassDDL.New(mysql.ErrColumnCheckConstraintReferOther, mysql.MySQLErrName[mysql.ErrColumnCheckConstraintReferOther])
 	// ErrTableCheckConstraintReferUnknown is returned when create table check constraint referring non-existing column.
 	ErrTableCheckConstraintReferUnknown = terror.ClassDDL.New(mysql.ErrTableCheckConstraintReferUnknown, mysql.MySQLErrName[mysql.ErrTableCheckConstraintReferUnknown])
+	// ErrConstraintDoesNotExist is returned for dropping a non-existent constraint.
+	ErrConstraintDoesNotExist = terror.ClassDDL.New(mysql.ErrConstraintDoesNotExist, mysql.MySQLErrName[mysql.ErrConstraintDoesNotExist])
+	// ErrCheckConstraintIsViolated is returned for violating the a existed check constraint.
+	ErrCheckConstraintIsViolated = terror.ClassDDL.New(mysql.ErrCheckConstraintIsViolated, mysql.MySQLErrName[mysql.ErrCheckConstraintIsViolated])
 )

--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -945,12 +945,15 @@ const (
 	ErrFKIncompatibleColumns                                        = 3780
 	ErrFunctionalIndexRowValueIsNotAllowed                          = 3800
 	ErrColumnCheckConstraintReferOther                              = 3813
+	ErrCheckConstraintIsViolated                                    = 3819
 	ErrTableCheckConstraintReferUnknown                             = 3820
+	ErrCheckConstraintDuplicate                                     = 3822
 	ErrDependentByFunctionalIndex                                   = 3837
 	ErrInvalidJSONValueForFuncIndex                                 = 3903
 	ErrJSONValueOutOfRangeForFuncIndex                              = 3904
 	ErrFunctionalIndexDataIsTooLong                                 = 3907
 	ErrFunctionalIndexNotApplicable                                 = 3909
+	ErrConstraintDoesNotExist                                       = 3940
 
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed         = 4030

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -942,12 +942,15 @@ var MySQLErrName = map[uint16]string{
 	ErrFKIncompatibleColumns:                                 "Referencing column '%s' in foreign key constraint '%s' are incompatible",
 	ErrFunctionalIndexRowValueIsNotAllowed:                   "Expression of functional index '%s' cannot refer to a row value",
 	ErrColumnCheckConstraintReferOther:                       "Column check constraint '%s' references other column.",
+	ErrCheckConstraintIsViolated:                             "Check constraint '%s' is violated",
 	ErrTableCheckConstraintReferUnknown:                      "Check constraint '%s' refers to non-existing column '%s'.",
+	ErrCheckConstraintDuplicate:                              "Duplicate check constraint name '%s'.",
 	ErrDependentByFunctionalIndex:                            "Column '%s' has a functional index dependency and cannot be dropped or renamed",
 	ErrInvalidJSONValueForFuncIndex:                          "Invalid JSON value for CAST for functional index '%s'",
 	ErrJSONValueOutOfRangeForFuncIndex:                       "Out of range JSON value for CAST for functional index '%s'",
 	ErrFunctionalIndexDataIsTooLong:                          "Data too long for functional index '%s'",
 	ErrFunctionalIndexNotApplicable:                          "Cannot use functional index '%s' due to type or collation conversion",
+	ErrConstraintDoesNotExist:                                "Constraint '%s' does not exist",
 
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed:         "Only one DEFAULT partition allowed",

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dgraph-io/ristretto v0.0.1
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/go-sql-driver/mysql v1.4.1
+	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.4
@@ -75,3 +75,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/ailinkid/parser v0.0.0-20200528073630-0b98f021b9d5

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/ailinkid/parser v0.0.0-20200528073630-0b98f021b9d5 h1:S0wRdgEopaLeE+36naNKKZFTjhkVUhYMwwFbkW0wgXk=
+github.com/ailinkid/parser v0.0.0-20200528073630-0b98f021b9d5/go.mod h1:vQdbJqobJAgFyiRNNtXahpMoGWwPEuWciVEK5A20NS0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -117,6 +119,8 @@ github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEK
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -284,8 +288,6 @@ github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfE
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad h1:SveG82rmu/GFxYanffxsSF503SiQV+2JLnWEiGiF+Tc=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20200602044958-becdf8cc583d h1:NsvWIRtiuEq6ciTvn4tnEyvvV1ZIhCU9eTQXbhbOQWM=
-github.com/pingcap/parser v0.0.0-20200602044958-becdf8cc583d/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2 h1:JTzYYukREvxVSKW/ncrzNjFitd8snoQ/Xz32pw8i+s8=
 github.com/pingcap/pd/v4 v4.0.0-rc.1.0.20200422143320-428acd53eba2/go.mod h1:s+utZtXDznOiL24VK0qGmtoHjjXNsscJx3m1n8cC56s=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
@@ -293,7 +295,6 @@ github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1 h1:PI8YpTl45F8ilNk
 github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incompatible h1:84F7MFMfdAYObrznvRslmVu43aoihrlL+7mMyMlOi0o=
 github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200417094153-7316d94df1ee h1:XJQ6/LGzOSc/jo33AD8t7jtc4GohxcyODsYnb+kZXJM=
 github.com/pingcap/tipb v0.0.0-20200417094153-7316d94df1ee/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/infoschema/error.go
+++ b/infoschema/error.go
@@ -43,6 +43,8 @@ var (
 	ErrNonuniqTable = terror.ClassSchema.New(mysql.ErrNonuniqTable, mysql.MySQLErrName[mysql.ErrNonuniqTable])
 	// ErrMultiplePriKey returns for multiple primary keys.
 	ErrMultiplePriKey = terror.ClassSchema.New(mysql.ErrMultiplePriKey, mysql.MySQLErrName[mysql.ErrMultiplePriKey])
+	// ErrCheckConstraintDuplicate returns for duplicate constraint names.
+	ErrCheckConstraintDuplicate = terror.ClassSchema.New(mysql.ErrCheckConstraintDuplicate, mysql.MySQLErrName[mysql.ErrCheckConstraintDuplicate])
 	// ErrTooManyKeyParts returns for too many key parts.
 	ErrTooManyKeyParts = terror.ClassSchema.New(mysql.ErrTooManyKeyParts, mysql.MySQLErrName[mysql.ErrTooManyKeyParts])
 	// ErrForeignKeyNotExists returns for foreign key not exists.


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
support alter table with constraint ddl action.
```
create table t(a int);

**Add constraint**:
alter table t add constraint haha check(a >1);

> Attention: check constraint will fetch the data from table to check.

**Alter constraint**:
alter table t alter constraint haha enforced;

> Attention: not enforced check constraint will allow the violated data to insert, but when change a constraint from not enforced to enforced, it will fetch the data to check constraint.

**Drop constraint**:
alter table t drop constraint haha;
```

### What is changed and how it works?
Schema State: **None** -> **Write Only** -> **Public**
**None**: Node in this state will not perceive the constraint existence, and the inserted data may violate the check constraint.

**Write Only**: Node in this state will actually see check constraint existence, but the inserted data will check the constraint rule. If broken, ddl fails.

**Public**: on the way from **Write Only** to **Public**, ddl owner will fetch the old data previous to **Write Only** state, and check the data whether it's satisfied the check constraint rule. If broken, ddl fails. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has interface methods change

Release note

 - Write release note for bug-fix or new feature.
 - ddl: support alter table add/drop/alter check constraint
