### PR TITLE
executor: support show create table with check constraints

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -878,6 +878,25 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		}
 	}
 
+	publicConstraints := make([]*model.ConstraintInfo, 0, len(tableInfo.Indices))
+	for _, constr := range tableInfo.Constraints {
+		if constr.State == model.StatePublic {
+			publicConstraints = append(publicConstraints, constr)
+		}
+	}
+	if len(publicConstraints) > 0 {
+		buf.WriteString(",\n")
+	}
+	for i, constrInfo := range publicConstraints {
+		fmt.Fprintf(buf, "CONSTRAINT %s CHECK ((%s))", stringutil.Escape(constrInfo.Name.O, sqlMode), constrInfo.ExprString)
+		if !constrInfo.Enforced {
+			buf.WriteString(" /*!80016 NOT ENFORCED */")
+		}
+		if i != len(publicConstraints)-1 {
+			buf.WriteString(",\n")
+		}
+	}
+
 	buf.WriteString("\n")
 
 	buf.WriteString(") ENGINE=InnoDB")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -855,3 +855,36 @@ func (s *testSuite5) TestShowClusterConfig(c *C) {
 	confErr = fmt.Errorf("something unknown error")
 	c.Assert(tk.QueryToErr("show config"), ErrorMatches, confErr.Error())
 }
+
+func (s *testSuite5) TestShowCheckConstraint(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t")
+	// Create table with check constraint
+	tk.MustExec("create table t(a int check (a>1), b int, constraint my_constr check(a<10))")
+	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
+		"  `a` int(11) DEFAULT NULL,\n" +
+		"  `b` int(11) DEFAULT NULL,\n" +
+		"CONSTRAINT `my_constr` CHECK ((`a` < 10)),\n" +
+		"CONSTRAINT `t_chk_1` CHECK ((`a` > 1))\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
+	// Alter table add constraint.
+	tk.MustExec("alter table t add constraint my_constr2 check (a<b) not enforced")
+	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
+		"  `a` int(11) DEFAULT NULL,\n" +
+		"  `b` int(11) DEFAULT NULL,\n" +
+		"CONSTRAINT `my_constr` CHECK ((`a` < 10)),\n" +
+		"CONSTRAINT `t_chk_1` CHECK ((`a` > 1)),\n" +
+		"CONSTRAINT `my_constr2` CHECK ((`a` < `b`)) /*!80016 NOT ENFORCED */\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
+	// Alter table drop constraint.
+	tk.MustExec("alter table t drop constraint t_chk_1")
+	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
+		"  `a` int(11) DEFAULT NULL,\n" +
+		"  `b` int(11) DEFAULT NULL,\n" +
+		"CONSTRAINT `my_constr` CHECK ((`a` < 10)),\n" +
+		"CONSTRAINT `my_constr2` CHECK ((`a` < `b`)) /*!80016 NOT ENFORCED */\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
+	tk.MustExec("drop table if exists t")
+}


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close: part of https://github.com/pingcap/tidb/issues/17430

support show create table with check constraints
```
create table t(a int check(a>1));    
+----------+-----------------------------------------------------------------------------------------------------+
| Table    | Create Table                                                                                                     |
+----------+-----------------------------------------------------------------------------------------------------+
| t        | CREATE TABLE `t` (                                                                                        |
|          |   `a` int(11) DEFAULT NULL,                                                                            |
|          | CONSTRAINT `t_chk_1` CHECK ((`a` > 1))                                                    |
|          | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin  |
+----------+-----------------------------------------------------------------------------------------------------+
```

### What is changed and how it works?
travel the constraints in tableinfo in show.go and print it out.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - executor: support show create table with check constraints.
