### PR TITLE
planner: add basic support for column privilege

### DIFF
--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -871,6 +871,12 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 		ans []visitInfo
 	}{
 		{
+			sql: "select a from t",
+			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", nil},
+			},
+		},
+		{
 			sql: "insert into t (a) values (1)",
 			ans: []visitInfo{
 				{mysql.InsertPriv, "test", "t", "", nil},
@@ -880,41 +886,54 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 			sql: "delete from t where a = 1",
 			ans: []visitInfo{
 				{mysql.DeletePriv, "test", "t", "", nil},
-				{mysql.SelectPriv, "test", "t", "", nil},
+				// {mysql.SelectPriv, "test", "t", "", nil},
 			},
 		},
 		{
 			sql: "delete from a1 using t as a1 inner join t as a2 where a1.a = a2.a",
 			ans: []visitInfo{
 				{mysql.DeletePriv, "test", "t", "", nil},
-				{mysql.SelectPriv, "test", "t", "", nil},
+				// {mysql.SelectPriv, "test", "t", "", nil},
 			},
 		},
 		{
 			sql: "update t set a = 7 where a = 1",
 			ans: []visitInfo{
-				{mysql.UpdatePriv, "test", "t", "", nil},
+				{mysql.UpdatePriv, "test", "t", "a", nil},
 				{mysql.SelectPriv, "test", "t", "", nil},
 			},
 		},
 		{
 			sql: "update t, (select * from t) a1 set t.a = a1.a;",
 			ans: []visitInfo{
+				{mysql.SelectPriv, "test", "t", "a", nil},
+				{mysql.SelectPriv, "test", "t", "b", nil},
+				{mysql.SelectPriv, "test", "t", "c", nil},
+				{mysql.SelectPriv, "test", "t", "d", nil},
+				{mysql.SelectPriv, "test", "t", "e", nil},
+				{mysql.SelectPriv, "test", "t", "c_str", nil},
+				{mysql.SelectPriv, "test", "t", "d_str", nil},
+				{mysql.SelectPriv, "test", "t", "e_str", nil},
+				{mysql.SelectPriv, "test", "t", "f", nil},
+				{mysql.SelectPriv, "test", "t", "g", nil},
+				{mysql.SelectPriv, "test", "t", "h", nil},
+				{mysql.SelectPriv, "test", "t", "i_date", nil},
 				{mysql.UpdatePriv, "test", "t", "", nil},
-				{mysql.SelectPriv, "test", "t", "", nil},
+				{mysql.SelectPriv, "test", "t", "a", nil},
 			},
 		},
 		{
 			sql: "update t a1 set a1.a = a1.a + 1",
 			ans: []visitInfo{
-				{mysql.UpdatePriv, "test", "t", "", nil},
+				{mysql.UpdatePriv, "test", "t", "a", nil},
 				{mysql.SelectPriv, "test", "t", "", nil},
 			},
 		},
 		{
 			sql: "select a, sum(e) from t group by a",
 			ans: []visitInfo{
-				{mysql.SelectPriv, "test", "t", "", nil},
+				{mysql.SelectPriv, "test", "t", "e", nil},
+				{mysql.SelectPriv, "test", "t", "a", nil},
 			},
 		},
 		{

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3189,3 +3189,27 @@ func (s *testSchemaSuite) TestTxnSize(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(txn.Size() > 0, IsTrue)
 }
+
+func (s *testSessionSuite2) TestColumnPrivilege(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists column_table")
+	tk.MustExec("create table column_table (a int, b int, c int)")
+	tk.MustExec("create user 'column'")
+	// Grant select privilege on column.
+	tk.MustExec("grant select(b) on column_table to 'column'@'%'")
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	c.Assert(tk1.Se.Auth(&auth.UserIdentity{Username: "column", Hostname: "localhost"}, nil, nil), IsTrue)
+	tk1.MustQuery("select b from column_table")
+	err := tk1.ExecToErr("select * from column_table")
+	c.Assert(err, NotNil)
+	err = tk1.ExecToErr("select a from column_table")
+	c.Assert(err, NotNil)
+
+	// Grant update privilege on column.
+	tk.MustExec("grant select, update(b) on column_table to 'column'@'%'")
+	tk1.MustQuery("select * from column_table")
+	tk1.MustExec("update column_table set b = b + 1")
+	err = tk1.ExecToErr("update column_table set a = a + 1")
+	c.Assert(err, NotNil)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Some tiny changes to support column level privilege.

### What is changed and how it works?

In the old code, `addVisitInfo` is add in the `buildDataSource`, there is no column information there.
To support column privilege, the visited column information must be accurate.
So `addVisitInfo` is moved from `buildDataSource` to `buildProjection` where the column is available.

In `buildUpdate`, the column is set for `addVisitInfo`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test



Side effects

 - Possible performance regression

