### PR TITLE
*: support list columns partition table

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -855,15 +855,15 @@ func (s *testIntegrationSuite5) TestAlterTableAddPartitionByList(c *C) {
 
 	c.Assert(part.Expr, Equals, "`id`")
 	c.Assert(part.Definitions, HasLen, 5)
-	c.Assert(part.Definitions[0].InValues, DeepEquals, []string{"1", "2"})
+	c.Assert(part.Definitions[0].InValues, DeepEquals, [][]string{{"1"}, {"2"}})
 	c.Assert(part.Definitions[0].Name, Equals, model.NewCIStr("p0"))
-	c.Assert(part.Definitions[1].InValues, DeepEquals, []string{"3", "4"})
+	c.Assert(part.Definitions[1].InValues, DeepEquals, [][]string{{"3"}, {"4"}})
 	c.Assert(part.Definitions[1].Name, Equals, model.NewCIStr("p1"))
-	c.Assert(part.Definitions[2].InValues, DeepEquals, []string{"5", "NULL"})
+	c.Assert(part.Definitions[2].InValues, DeepEquals, [][]string{{"5"}, {"NULL"}})
 	c.Assert(part.Definitions[2].Name, Equals, model.NewCIStr("p3"))
-	c.Assert(part.Definitions[3].InValues, DeepEquals, []string{"7"})
+	c.Assert(part.Definitions[3].InValues, DeepEquals, [][]string{{"7"}})
 	c.Assert(part.Definitions[3].Name, Equals, model.NewCIStr("p4"))
-	c.Assert(part.Definitions[4].InValues, DeepEquals, []string{"8", "9"})
+	c.Assert(part.Definitions[4].InValues, DeepEquals, [][]string{{"8"}, {"9"}})
 	c.Assert(part.Definitions[4].Name, Equals, model.NewCIStr("p5"))
 
 	errorCases := []struct {
@@ -881,6 +881,75 @@ func (s *testIntegrationSuite5) TestAlterTableAddPartitionByList(c *C) {
 		},
 		{"alter table t add partition (partition p6 values in (7))",
 			ddl.ErrMultipleDefConstInListPart,
+		},
+		{"alter table t add partition (partition p6 values in ('a'))",
+			ddl.ErrNotAllowedTypeInPartition,
+		},
+	}
+
+	for i, t := range errorCases {
+		_, err := tk.Exec(t.sql)
+		c.Assert(t.err.Equal(err), IsTrue, Commentf(
+			"case %d fail, sql = `%s`\nexpected error = `%v`\n  actual error = `%v`",
+			i, t.sql, t.err, err,
+		))
+	}
+}
+
+func (s *testIntegrationSuite5) TestAlterTableAddPartitionByListColumns(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec(`create table t (id int, name varchar(10)) partition by list columns (id,name) (
+	    partition p0 values in ((1,'a'),(2,'b')),
+	    partition p1 values in ((3,'a'),(4,'b')),
+	    partition p3 values in ((5,null))
+	);`)
+	tk.MustExec(`alter table t add partition (
+		partition p4 values in ((7,'a')),
+		partition p5 values in ((8,'a')));`)
+
+	ctx := tk.Se.(sessionctx.Context)
+	is := domain.GetDomain(ctx).InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	c.Assert(tbl.Meta().Partition, NotNil)
+	part := tbl.Meta().Partition
+	c.Assert(part.Type == model.PartitionTypeList, IsTrue)
+
+	c.Assert(part.Expr, Equals, "")
+	c.Assert(part.Columns[0].O, Equals, "id")
+	c.Assert(part.Columns[1].O, Equals, "name")
+	c.Assert(part.Definitions, HasLen, 5)
+	c.Assert(part.Definitions[0].InValues, DeepEquals, [][]string{{"1", `"a"`}, {"2", `"b"`}})
+	c.Assert(part.Definitions[0].Name, Equals, model.NewCIStr("p0"))
+	c.Assert(part.Definitions[1].InValues, DeepEquals, [][]string{{"3", `"a"`}, {"4", `"b"`}})
+	c.Assert(part.Definitions[1].Name, Equals, model.NewCIStr("p1"))
+	c.Assert(part.Definitions[2].InValues, DeepEquals, [][]string{{"5", `NULL`}})
+	c.Assert(part.Definitions[2].Name, Equals, model.NewCIStr("p3"))
+	c.Assert(part.Definitions[3].InValues, DeepEquals, [][]string{{"7", `"a"`}})
+	c.Assert(part.Definitions[3].Name, Equals, model.NewCIStr("p4"))
+	c.Assert(part.Definitions[4].InValues, DeepEquals, [][]string{{"8", `"a"`}})
+	c.Assert(part.Definitions[4].Name, Equals, model.NewCIStr("p5"))
+
+	errorCases := []struct {
+		sql string
+		err *terror.Error
+	}{
+		{"alter table t add partition (partition p4 values in ((7,'b')))",
+			ddl.ErrSameNamePartition,
+		},
+		{"alter table t add partition (partition p6 values less than ((7,'a')))",
+			ast.ErrPartitionWrongValues,
+		},
+		{"alter table t add partition (partition p6 values in ((5,null)))",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{"alter table t add partition (partition p6 values in ((7,'a')))",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{"alter table t add partition (partition p6 values in (('a','a')))",
+			ddl.ErrNotAllowedTypeInPartition,
 		},
 	}
 
@@ -910,12 +979,44 @@ func (s *testIntegrationSuite5) TestAlterTableDropPartitionByList(c *C) {
 	c.Assert(tbl.Meta().Partition, NotNil)
 	part := tbl.Meta().Partition
 	c.Assert(part.Type == model.PartitionTypeList, IsTrue)
-
 	c.Assert(part.Expr, Equals, "`id`")
 	c.Assert(part.Definitions, HasLen, 2)
-	c.Assert(part.Definitions[0].InValues, DeepEquals, []string{"1", "2"})
+	c.Assert(part.Definitions[0].InValues, DeepEquals, [][]string{{"1"}, {"2"}})
 	c.Assert(part.Definitions[0].Name, Equals, model.NewCIStr("p0"))
-	c.Assert(part.Definitions[1].InValues, DeepEquals, []string{"5", "NULL"})
+	c.Assert(part.Definitions[1].InValues, DeepEquals, [][]string{{"5"}, {"NULL"}})
+	c.Assert(part.Definitions[1].Name, Equals, model.NewCIStr("p3"))
+
+	sql := "alter table t drop partition p10;"
+	tk.MustGetErrCode(sql, tmysql.ErrDropPartitionNonExistent)
+	tk.MustExec(`alter table t drop partition p3`)
+	sql = "alter table t drop partition p0;"
+	tk.MustGetErrCode(sql, tmysql.ErrDropLastPartition)
+}
+
+func (s *testIntegrationSuite5) TestAlterTableDropPartitionByListColumns(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec(`create table t (id int, name varchar(10)) partition by list columns (id,name) (
+	    partition p0 values in ((1,'a'),(2,'b')),
+	    partition p1 values in ((3,'a'),(4,'b')),
+	    partition p3 values in ((5,'a'),(null,null))
+	);`)
+	tk.MustExec(`alter table t drop partition p1`)
+	ctx := tk.Se.(sessionctx.Context)
+	is := domain.GetDomain(ctx).InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	c.Assert(tbl.Meta().Partition, NotNil)
+	part := tbl.Meta().Partition
+	c.Assert(part.Type == model.PartitionTypeList, IsTrue)
+	c.Assert(part.Expr, Equals, "")
+	c.Assert(part.Columns[0].O, Equals, "id")
+	c.Assert(part.Columns[1].O, Equals, "name")
+	c.Assert(part.Definitions, HasLen, 2)
+	c.Assert(part.Definitions[0].InValues, DeepEquals, [][]string{{"1", `"a"`}, {"2", `"b"`}})
+	c.Assert(part.Definitions[0].Name, Equals, model.NewCIStr("p0"))
+	c.Assert(part.Definitions[1].InValues, DeepEquals, [][]string{{"5", `"a"`}, {"NULL", "NULL"}})
 	c.Assert(part.Definitions[1].Name, Equals, model.NewCIStr("p3"))
 
 	sql := "alter table t drop partition p10;"

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -492,6 +492,10 @@ func (s *testIntegrationSuite1) TestCreateTableWithListPartition(c *C) {
 			ddl.ErrSameNamePartition,
 		},
 		{
+			"create table t (a int) partition by list (a) (partition p0 values in (1), partition P0 values in (2));",
+			ddl.ErrSameNamePartition,
+		},
+		{
 			"create table t (a int) partition by list (a) (partition p0 values in (1), partition p1 values in (1));",
 			ddl.ErrMultipleDefConstInListPart,
 		},
@@ -530,6 +534,8 @@ func (s *testIntegrationSuite1) TestCreateTableWithListPartition(c *C) {
 			partition p2 values in (4,12,13,-14,18),
 			partition p3 values in (7,8,15,+16)
 		);`,
+		"create table t (a bigint) partition by list (a) (partition p0 values in (to_seconds('2020-09-28 17:03:38'),to_seconds('2020-09-28 17:03:39')));",
+		"create table t (a datetime) partition by list (to_seconds(a)) (partition p0 values in (to_seconds('2020-09-28 17:03:38'),to_seconds('2020-09-28 17:03:39')));",
 	}
 
 	for _, sql := range validCases {
@@ -541,16 +547,131 @@ func (s *testIntegrationSuite1) TestCreateTableWithListPartition(c *C) {
 		c.Assert(tblInfo.Partition.Enable, Equals, true)
 		c.Assert(tblInfo.Partition.Type == model.PartitionTypeList, IsTrue)
 	}
+}
 
-	invalidCases := []string{
-		"create table t (a int) partition by list columns (a) (partition p0 values in (1));",
+func (s *testIntegrationSuite1) TestCreateTableWithListColumnsPartition(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("set @@session.tidb_enable_table_partition = 1")
+	tk.MustExec("drop table if exists t")
+	type errorCase struct {
+		sql string
+		err *terror.Error
 	}
-	for _, sql := range invalidCases {
+	cases := []errorCase{
+		{
+			"create table t (id int) partition by list columns (id);",
+			ast.ErrPartitionsMustBeDefined,
+		},
+		{
+			"create table t (a int) partition by list columns (b) (partition p0 values in (1));",
+			ddl.ErrFieldNotFoundPart,
+		},
+		{
+			"create table t (id timestamp) partition by list columns (id) (partition p0 values in ('2019-01-09 11:23:34'));",
+			ddl.ErrNotAllowedTypeInPartition,
+		},
+		{
+			"create table t (id decimal) partition by list columns (id) (partition p0 values in ('2019-01-09 11:23:34'));",
+			ddl.ErrNotAllowedTypeInPartition,
+		},
+		{
+			"create table t (a int) partition by list columns (a) (partition p0 values in (1), partition p0 values in (2));",
+			ddl.ErrSameNamePartition,
+		},
+		{
+			"create table t (a int) partition by list columns (a) (partition p0 values in (1), partition P0 values in (2));",
+			ddl.ErrSameNamePartition,
+		},
+		{
+			"create table t (a int) partition by list columns (a) (partition p0 values in (1), partition p1 values in (1));",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a int) partition by list columns (a) (partition p0 values in (1), partition p1 values in (+1));",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a tinyint) partition by list columns (a) (partition p0 values in (1), partition p1 values in (+1));",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a mediumint) partition by list columns (a) (partition p0 values in (1), partition p1 values in (+1));",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a bigint) partition by list columns (a) (partition p0 values in (1), partition p1 values in (+1));",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a bigint) partition by list columns (a) (partition p0 values in (1,+1))",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a int) partition by list columns (a) (partition p0 values in (null), partition p1 values in (NULL));",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a bigint, b int) partition by list columns (a,b) (partition p0 values in ((1,2),(1,2)))",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			"create table t (a bigint, b int) partition by list columns (a,b) (partition p0 values in ((1,1),(2,2)), partition p1 values in ((+1,1)));",
+			ddl.ErrMultipleDefConstInListPart,
+		},
+		{
+			`create table t1 (id int key, name varchar(10), unique index idx(name)) partition by list columns (id) (
+				    partition p0 values in (3,5,6,9,17),
+				    partition p1 values in (1,2,10,11,19,20),
+				    partition p2 values in (4,12,13,14,18),
+				    partition p3 values in (7,8,15,16)
+				);`,
+			ddl.ErrUniqueKeyNeedAllFieldsInPf,
+		},
+		{
+			"create table t (a int, b varchar(10)) partition by list columns (a,b) (partition p0 values in (1));",
+			ast.ErrPartitionColumnList,
+		},
+		{
+			"create table t (a int, b varchar(10)) partition by list columns (a,b) (partition p0 values in (('ab','ab')));",
+			ddl.ErrNotAllowedTypeInPartition,
+		},
+		{
+			"create table t (a int, b datetime) partition by list columns (a,b) (partition p0 values in ((1)));",
+			ast.ErrPartitionColumnList,
+		},
+	}
+	for i, t := range cases {
+		_, err := tk.Exec(t.sql)
+		c.Assert(t.err.Equal(err), IsTrue, Commentf(
+			"case %d fail, sql = `%s`\nexpected error = `%v`\n  actual error = `%v`",
+			i, t.sql, t.err, err,
+		))
+	}
+
+	validCases := []string{
+		"create table t (a int) partition by list columns (a) (partition p0 values in (1));",
+		"create table t (a int) partition by list columns (a) (partition p0 values in (1), partition p1 values in (2));",
+		`create table t (id int, name varchar(10), age int) partition by list columns (id) (
+			partition p0 values in (3,5,6,9,17),
+			partition p1 values in (1,2,10,11,19,20),
+			partition p2 values in (4,12,13,-14,18),
+			partition p3 values in (7,8,15,+16)
+		);`,
+		"create table t (a datetime) partition by list columns (a) (partition p0 values in ('2020-09-28 17:03:38','2020-09-28 17:03:39'));",
+		"create table t (a date) partition by list columns (a) (partition p0 values in ('2020-09-28','2020-09-29'));",
+		"create table t (a bigint, b date) partition by list columns (a,b) (partition p0 values in ((1,'2020-09-28'),(1,'2020-09-29')));",
+		"create table t (a bigint)   partition by list columns (a) (partition p0 values in (to_seconds('2020-09-28 17:03:38'),to_seconds('2020-09-28 17:03:39')));",
+	}
+
+	for _, sql := range validCases {
 		tk.MustExec("drop table if exists t")
 		tk.MustExec(sql)
 		tbl := testGetTableByName(c, s.ctx, "test", "t")
 		tblInfo := tbl.Meta()
-		c.Assert(tblInfo.Partition, IsNil)
+		c.Assert(tblInfo.Partition, NotNil)
+		c.Assert(tblInfo.Partition.Enable, Equals, true)
+		c.Assert(tblInfo.Partition.Type == model.PartitionTypeList, IsTrue)
 	}
 }
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1931,14 +1931,14 @@ func checkPartitionByRange(ctx sessionctx.Context, tbInfo *model.TableInfo, s *a
 	}
 
 	// Check for range columns partition.
-	if err := checkRangeColumnsPartitionType(tbInfo); err != nil {
+	if err := checkColumnsPartitionType(tbInfo); err != nil {
 		return err
 	}
 
 	if s != nil {
 		for _, def := range s.Partition.Definitions {
 			exprs := def.Clause.(*ast.PartitionDefinitionClauseLessThan).Exprs
-			if err := checkRangeColumnsTypeAndValuesMatch(ctx, tbInfo, exprs); err != nil {
+			if err := checkColumnsTypeAndValuesMatch(ctx, tbInfo, exprs); err != nil {
 				return err
 			}
 		}
@@ -1947,7 +1947,7 @@ func checkPartitionByRange(ctx sessionctx.Context, tbInfo *model.TableInfo, s *a
 	return checkRangeColumnsPartitionValue(ctx, tbInfo)
 }
 
-// checkPartitionByRange checks validity of a "BY RANGE" partition.
+// checkPartitionByList checks validity of a "BY LIST" partition.
 func checkPartitionByList(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.CreateTableStmt) error {
 	pi := tbInfo.Partition
 	if err := checkPartitionNameUnique(pi); err != nil {
@@ -1958,14 +1958,7 @@ func checkPartitionByList(ctx sessionctx.Context, tbInfo *model.TableInfo, s *as
 		return err
 	}
 
-	if len(pi.Definitions) == 0 {
-		return ast.ErrPartitionsMustBeDefined.GenWithStackByArgs("LIST")
-	}
-
-	if len(pi.Columns) != 0 {
-		return fmt.Errorf("not support list columns partition")
-	}
-	if err := checkListPartitionValue(tbInfo); err != nil {
+	if err := checkListPartitionValue(ctx, tbInfo); err != nil {
 		return err
 	}
 
@@ -1973,14 +1966,30 @@ func checkPartitionByList(ctx sessionctx.Context, tbInfo *model.TableInfo, s *as
 	if s == nil {
 		return nil
 	}
-
-	if err := checkPartitionFuncValid(ctx, tbInfo, s.Partition.Expr); err != nil {
+	if len(pi.Columns) == 0 {
+		if err := checkPartitionFuncValid(ctx, tbInfo, s.Partition.Expr); err != nil {
+			return err
+		}
+		return checkPartitionFuncType(ctx, s, tbInfo)
+	}
+	if err := checkColumnsPartitionType(tbInfo); err != nil {
 		return err
 	}
-	return checkPartitionFuncType(ctx, s, tbInfo)
+
+	if len(pi.Columns) > 0 {
+		for _, def := range s.Partition.Definitions {
+			inValues := def.Clause.(*ast.PartitionDefinitionClauseIn).Values
+			for _, vs := range inValues {
+				if err := checkColumnsTypeAndValuesMatch(ctx, tbInfo, vs); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
-func checkRangeColumnsPartitionType(tbInfo *model.TableInfo) error {
+func checkColumnsPartitionType(tbInfo *model.TableInfo) error {
 	for _, col := range tbInfo.Partition.Columns {
 		colInfo := getColumnInfoByName(tbInfo, col.L)
 		if colInfo == nil {
@@ -4528,8 +4537,6 @@ func buildPartitionInfo(ctx sessionctx.Context, meta *model.TableInfo, d *ddl, s
 		}
 		if meta.Partition.Type == model.PartitionTypeRange {
 			err = buildRangePartitionInfo(ctx, meta, part, def, &piDef)
-		} else {
-			err = buildListPartitionInfo(ctx, meta, part, def, &piDef)
 		}
 		if err != nil {
 			return nil, err
@@ -4543,7 +4550,7 @@ func buildRangePartitionInfo(ctx sessionctx.Context, meta *model.TableInfo, part
 	// For RANGE partition only VALUES LESS THAN should be possible.
 	clause := def.Clause.(*ast.PartitionDefinitionClauseLessThan)
 	if len(part.Columns) > 0 {
-		if err := checkRangeColumnsTypeAndValuesMatch(ctx, meta, clause.Exprs); err != nil {
+		if err := checkColumnsTypeAndValuesMatch(ctx, meta, clause.Exprs); err != nil {
 			return err
 		}
 	}
@@ -4556,22 +4563,7 @@ func buildRangePartitionInfo(ctx sessionctx.Context, meta *model.TableInfo, part
 	return nil
 }
 
-func buildListPartitionInfo(ctx sessionctx.Context, meta *model.TableInfo, part *model.PartitionInfo, def *ast.PartitionDefinition, piDef *model.PartitionDefinition) error {
-	// For List partition only VALUES IN should be possible.
-	clause := def.Clause.(*ast.PartitionDefinitionClauseIn)
-	buf := new(bytes.Buffer)
-	for _, vs := range clause.Values {
-		if len(vs) != 1 {
-			return fmt.Errorf("not support muli-column list partition")
-		}
-		vs[0].Format(buf)
-		piDef.InValues = append(piDef.InValues, buf.String())
-		buf.Reset()
-	}
-	return nil
-}
-
-func checkRangeColumnsTypeAndValuesMatch(ctx sessionctx.Context, meta *model.TableInfo, exprs []ast.ExprNode) error {
+func checkColumnsTypeAndValuesMatch(ctx sessionctx.Context, meta *model.TableInfo, exprs []ast.ExprNode) error {
 	// Validate() has already checked len(colNames) = len(exprs)
 	// create table ... partition by range columns (cols)
 	// partition p0 values less than (expr)
@@ -4601,6 +4593,46 @@ func checkRangeColumnsTypeAndValuesMatch(ctx sessionctx.Context, meta *model.Tab
 			case types.KindString, types.KindBytes:
 			default:
 				return ErrWrongTypeColumnValue.GenWithStackByArgs()
+			}
+		}
+	}
+	return nil
+}
+
+func formatListPartitionValue(ctx sessionctx.Context, tblInfo *model.TableInfo) error {
+	defs := tblInfo.Partition.Definitions
+	pi := tblInfo.Partition
+	var colTps []*types.FieldType
+	if len(pi.Columns) == 0 {
+		tp := types.NewFieldType(mysql.TypeLonglong)
+		if isRangePartitionColUnsignedBigint(tblInfo.Columns, tblInfo.Partition) {
+			tp.Flag |= mysql.UnsignedFlag
+		}
+		colTps = []*types.FieldType{tp}
+	} else {
+		colTps = make([]*types.FieldType, 0, len(pi.Columns))
+		for _, colName := range pi.Columns {
+			colInfo := findColumnByName(colName.L, tblInfo)
+			if colInfo == nil {
+				return errors.Trace(ErrFieldNotFoundPart)
+			}
+			colTps = append(colTps, &colInfo.FieldType)
+		}
+	}
+	for i := range defs {
+		for j, vs := range defs[i].InValues {
+			for k, v := range vs {
+				if colTps[k].EvalType() != types.ETInt {
+					continue
+				}
+				isUnsigned := mysql.HasUnsignedFlag(colTps[k].Flag)
+				currentRangeValue, isNull, err := getListPartitionValue(ctx, v, isUnsigned)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				if !isNull {
+					defs[i].InValues[j][0] = fmt.Sprintf("%d", currentRangeValue)
+				}
 			}
 		}
 	}

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -70,10 +70,7 @@ func buildTablePartitionInfo(ctx sessionctx.Context, s *ast.CreateTableStmt) (*m
 	}
 
 	if s.Partition.Tp == model.PartitionTypeList {
-		// TODO: support list columns partition
-		if len(s.Partition.ColumnNames) == 0 {
-			enable = true
-		}
+		enable = true
 	}
 
 	if !enable {
@@ -95,7 +92,7 @@ func buildTablePartitionInfo(ctx sessionctx.Context, s *ast.CreateTableStmt) (*m
 		pi.Expr = buf.String()
 	} else if s.Partition.ColumnNames != nil {
 		// TODO: Support multiple columns for 'PARTITION BY RANGE COLUMNS'.
-		if len(s.Partition.ColumnNames) != 1 {
+		if s.Partition.Tp == model.PartitionTypeRange && len(s.Partition.ColumnNames) != 1 {
 			pi.Enable = false
 			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrUnsupportedPartitionByRangeColumns)
 		}
@@ -174,11 +171,13 @@ func buildListPartitionDefinitions(s *ast.CreateTableStmt, pi *model.PartitionIn
 
 		buf := new(bytes.Buffer)
 		for _, vs := range def.Clause.(*ast.PartitionDefinitionClauseIn).Values {
-			if len(vs) != 1 {
-				return fmt.Errorf("not support muli-column list partition")
+			inValue := make([]string, 0, len(vs))
+			for i := range vs {
+				buf.Reset()
+				vs[i].Format(buf)
+				inValue = append(inValue, buf.String())
 			}
-			vs[0].Format(buf)
-			piDef.InValues = append(piDef.InValues, buf.String())
+			piDef.InValues = append(piDef.InValues, inValue)
 			buf.Reset()
 		}
 		pi.Definitions = append(pi.Definitions, piDef)
@@ -551,44 +550,43 @@ func checkCreatePartitionValue(ctx sessionctx.Context, tblInfo *model.TableInfo)
 	return nil
 }
 
-func checkListPartitionValue(tblInfo *model.TableInfo) error {
+func checkListPartitionValue(ctx sessionctx.Context, tblInfo *model.TableInfo) error {
 	pi := tblInfo.Partition
-	defs := pi.Definitions
-	if len(defs) == 0 {
-		return nil
+	if len(pi.Definitions) == 0 {
+		return ast.ErrPartitionsMustBeDefined.GenWithStackByArgs("LIST")
+	}
+	if err := formatListPartitionValue(ctx, tblInfo); err != nil {
+		return err
 	}
 
-	cols := tblInfo.Columns
-	isUnsignedBigint := isRangePartitionColUnsignedBigint(cols, pi)
-	partitionsValuesMap := make(map[string]map[string]struct{})
-	checkMultipleValue := func(v string) error {
-		for _, otherValueMap := range partitionsValuesMap {
-			if _, ok := otherValueMap[v]; ok {
-				return errors.Trace(ErrMultipleDefConstInListPart)
+	var partitionsValuesMap []map[string]struct{}
+	partitionsValuesMap = append(partitionsValuesMap, make(map[string]struct{}))
+	for i := 1; i < len(pi.Columns); i++ {
+		partitionsValuesMap = append(partitionsValuesMap, make(map[string]struct{}))
+	}
+
+	checkUniqueValue := func(vs []string) error {
+		found := 0
+		for i, v := range vs {
+			m := partitionsValuesMap[i]
+			if _, ok := m[v]; ok {
+				found++
 			}
+			m[v] = struct{}{}
+		}
+		if found == len(vs) {
+			return errors.Trace(ErrMultipleDefConstInListPart)
 		}
 		return nil
 	}
 
 	for i, def := range pi.Definitions {
-		valuesMap := make(map[string]struct{}, len(def.InValues))
-		for j, v := range def.InValues {
-			if isUnsignedBigint {
-				if value, err := strconv.ParseUint(v, 10, 64); err == nil {
-					v = strconv.FormatUint(value, 10)
-				}
-			} else {
-				if value, err := strconv.ParseInt(v, 10, 64); err == nil {
-					v = strconv.FormatInt(value, 10)
-				}
-			}
-			if err := checkMultipleValue(v); err != nil {
+		for j, vs := range def.InValues {
+			if err := checkUniqueValue(vs); err != nil {
 				return err
 			}
-			pi.Definitions[i].InValues[j] = v
-			valuesMap[v] = struct{}{}
+			pi.Definitions[i].InValues[j] = vs
 		}
-		partitionsValuesMap[def.Name.O] = valuesMap
 	}
 	return nil
 }
@@ -621,6 +619,42 @@ func getRangeValue(ctx sessionctx.Context, tblInfo *model.TableInfo, str string,
 			if err2 == nil && !isNull {
 				return res, true, nil
 			}
+		}
+	}
+	return 0, false, ErrNotAllowedTypeInPartition.GenWithStackByArgs(str)
+}
+
+// getListPartitionValue gets an integer/null from the string value.
+// The returned boolean value indicates whether the input string is a null.
+func getListPartitionValue(ctx sessionctx.Context, str string, unsignedBigint bool) (interface{}, bool, error) {
+	if unsignedBigint {
+		if value, err := strconv.ParseUint(str, 10, 64); err == nil {
+			return value, false, nil
+		}
+
+		e, err1 := expression.ParseSimpleExprWithTableInfo(ctx, str, &model.TableInfo{})
+		if err1 != nil {
+			return 0, false, err1
+		}
+		res, isNull, err2 := e.EvalInt(ctx, chunk.Row{})
+		if err2 == nil {
+			return uint64(res), isNull, nil
+		}
+	} else {
+		if value, err := strconv.ParseInt(str, 10, 64); err == nil {
+			return value, false, nil
+		}
+		// The input value maybe not an integer, it could be a constant expression or null.
+		// For example:
+		// PARTITION p0 VALUES IN (TO_SECONDS('2004-01-01'))
+		// PARTITION p0 VALUES IN (NULL)
+		e, err1 := expression.ParseSimpleExprWithTableInfo(ctx, str, &model.TableInfo{})
+		if err1 != nil {
+			return 0, false, err1
+		}
+		res, isNull, err2 := e.EvalInt(ctx, chunk.Row{})
+		if err2 == nil {
+			return res, isNull, nil
 		}
 	}
 	return 0, false, ErrNotAllowedTypeInPartition.GenWithStackByArgs(str)

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -697,11 +697,28 @@ func (e *memtableRetriever) setDataFromPartitions(ctx sessionctx.Context, schema
 						avgRowLength = dataLength / rowCount
 					}
 
-					var partitionDesc interface{}
+					var partitionDesc string
 					if table.Partition.Type == model.PartitionTypeRange {
 						partitionDesc = pi.LessThan[0]
 					} else if table.Partition.Type == model.PartitionTypeList {
-						partitionDesc = strings.Join(pi.InValues, ",")
+						if len(pi.InValues) > 0 {
+							if len(pi.InValues[0]) == 1 {
+								for i, vs := range pi.InValues {
+									if i > 0 {
+										partitionDesc += ","
+									}
+									partitionDesc += vs[0]
+								}
+							} else if len(pi.InValues[0]) > 1 {
+								for i, vs := range pi.InValues {
+									if i > 0 {
+										partitionDesc += ","
+									}
+									partitionDesc += ("(" + strings.Join(vs, ",") + ")")
+								}
+
+							}
+						}
 					}
 
 					record := types.MakeDatums(

--- a/executor/show.go
+++ b/executor/show.go
@@ -1113,8 +1113,20 @@ func appendPartitionInfo(partitionInfo *model.PartitionInfo, buf *bytes.Buffer) 
 	}
 	if partitionInfo.Type == model.PartitionTypeList {
 		for i, def := range partitionInfo.Definitions {
-			values := strings.Join(def.InValues, ",")
-			fmt.Fprintf(buf, "  PARTITION `%s` VALUES IN (%s)", def.Name, values)
+			values := bytes.NewBuffer(nil)
+			for j, inValues := range def.InValues {
+				if j > 0 {
+					values.WriteString(",")
+				}
+				if len(inValues) > 1 {
+					values.WriteString("(")
+					values.WriteString(strings.Join(inValues, ","))
+					values.WriteString(")")
+				} else {
+					values.WriteString(strings.Join(inValues, ","))
+				}
+			}
+			fmt.Fprintf(buf, "  PARTITION `%s` VALUES IN (%s)", def.Name, values.String())
 			if i < len(partitionInfo.Definitions)-1 {
 				buf.WriteString(",\n")
 			} else {

--- a/executor/show.go
+++ b/executor/show.go
@@ -1096,6 +1096,19 @@ func appendPartitionInfo(partitionInfo *model.PartitionInfo, buf *bytes.Buffer) 
 			}
 		}
 		buf.WriteString(") (\n")
+	} else if partitionInfo.Type == model.PartitionTypeList {
+		if len(partitionInfo.Columns) == 0 {
+			fmt.Fprintf(buf, "\nPARTITION BY %s ( %s ) (\n", partitionInfo.Type.String(), partitionInfo.Expr)
+		} else {
+			colsName := ""
+			for _, col := range partitionInfo.Columns {
+				if len(colsName) > 0 {
+					colsName += ","
+				}
+				colsName += col.O
+			}
+			fmt.Fprintf(buf, "\nPARTITION BY LIST COLUMNS(%s) (\n", colsName)
+		}
 	} else {
 		fmt.Fprintf(buf, "\nPARTITION BY %s ( %s ) (\n", partitionInfo.Type.String(), partitionInfo.Expr)
 	}

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -696,6 +696,47 @@ func (s *testSuite5) TestShowCreateTable(c *C) {
 			"  PARTITION `p2` VALUES IN (4,12,13,14,18),\n"+
 			"  PARTITION `p3` VALUES IN (7,8,15,16,NULL)\n"+
 			")"))
+
+	// Test show list partition table
+	tk.MustExec(`DROP TABLE IF EXISTS t`)
+	tk.MustExec(`create table t (id int, name varchar(10), unique index idx (id)) partition by list  (id) (
+    	partition p0 values in (3,5,6,9,17),
+    	partition p1 values in (1,2,10,11,19,20),
+    	partition p2 values in (4,12,13,14,18),
+    	partition p3 values in (7,8,15,16,null)
+	);`)
+	tk.MustQuery(`show create table t`).Check(testutil.RowsWithSep("|",
+		"t CREATE TABLE `t` (\n"+
+			"  `id` int(11) DEFAULT NULL,\n"+
+			"  `name` varchar(10) DEFAULT NULL,\n"+
+			"  UNIQUE KEY `idx` (`id`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\n"+
+			"PARTITION BY LIST ( `id` ) (\n"+
+			"  PARTITION `p0` VALUES IN (3,5,6,9,17),\n"+
+			"  PARTITION `p1` VALUES IN (1,2,10,11,19,20),\n"+
+			"  PARTITION `p2` VALUES IN (4,12,13,14,18),\n"+
+			"  PARTITION `p3` VALUES IN (7,8,15,16,NULL)\n"+
+			")"))
+	// Test show list column partition table
+	tk.MustExec(`DROP TABLE IF EXISTS t`)
+	tk.MustExec(`create table t (id int, name varchar(10), unique index idx (id)) partition by list columns (id) (
+    	partition p0 values in (3,5,6,9,17),
+    	partition p1 values in (1,2,10,11,19,20),
+    	partition p2 values in (4,12,13,14,18),
+    	partition p3 values in (7,8,15,16,null)
+	);`)
+	tk.MustQuery(`show create table t`).Check(testutil.RowsWithSep("|",
+		"t CREATE TABLE `t` (\n"+
+			"  `id` int(11) DEFAULT NULL,\n"+
+			"  `name` varchar(10) DEFAULT NULL,\n"+
+			"  UNIQUE KEY `idx` (`id`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\n"+
+			"PARTITION BY LIST COLUMNS(id) (\n"+
+			"  PARTITION `p0` VALUES IN (3,5,6,9,17),\n"+
+			"  PARTITION `p1` VALUES IN (1,2,10,11,19,20),\n"+
+			"  PARTITION `p2` VALUES IN (4,12,13,14,18),\n"+
+			"  PARTITION `p3` VALUES IN (7,8,15,16,NULL)\n"+
+			")"))
 }
 
 func (s *testAutoRandomSuite) TestShowCreateTableAutoRandom(c *C) {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -2840,4 +2840,56 @@ func (s *testSuite4) TestWriteListPartitionTable(c *C) {
 	tk.MustQuery("select * from t partition (p1,p3) order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "7 f"))
 	tk.MustQuery("select * from t partition (p1,p3,p0,p2) order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "3 c", "4 d", "7 f"))
 	tk.MustQuery("select * from t order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "3 c", "4 d", "7 f"))
+	tk.MustExec("delete from t partition (p0)")
+	tk.MustQuery("select * from t order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "4 d", "7 f"))
+	tk.MustExec("delete from t partition (p3,p2)")
+	tk.MustQuery("select * from t order by id").Check(testkit.Rows("1 a", "2 b"))
+}
+
+func (s *testSuite4) TestWriteListColumnsPartitionTable(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_enable_table_partition = 1")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec(`create table t (id int, name varchar(10), unique index idx (id)) partition by list columns (id) (
+    	partition p0 values in (3,5,6,9,17),
+    	partition p1 values in (1,2,10,11,19,20),
+    	partition p2 values in (4,12,13,14,18),
+    	partition p3 values in (7,8,15,16,null)
+	);`)
+
+	// Test insert,update,delete
+	tk.MustExec("insert into t values  (1, 'a')")
+	tk.MustExec("update t set name='b' where id=2;")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 a"))
+	tk.MustExec("update t set name='b' where id=1;")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 b"))
+	tk.MustExec("replace into t values  (1, 'c')")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 c"))
+	tk.MustExec("insert into t values (1, 'd') on duplicate key update name='e'")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 e"))
+	tk.MustExec("delete from t where id=1")
+	tk.MustQuery("select * from t").Check(testkit.Rows())
+	tk.MustExec("insert into t values  (2, 'f')")
+	tk.MustExec("delete from t where name='f'")
+	tk.MustQuery("select * from t").Check(testkit.Rows())
+
+	// Test insert error
+	tk.MustExec("insert into t values  (1, 'a')")
+	_, err := tk.Exec("insert into t values (1, 'd')")
+	c.Assert(err.Error(), Equals, "[kv:1062]Duplicate entry '1' for key 'idx'")
+	_, err = tk.Exec("insert into t values (100, 'd')")
+	c.Assert(err.Error(), Equals, "[table:1526]Table has no partition for value from column_list")
+	tk.MustExec("admin check table t;")
+
+	// Test select partition
+	tk.MustExec("insert into t values  (2,'b'),(3,'c'),(4,'d'),(7,'f'), (null,null)")
+	tk.MustQuery("select * from t partition (p0) order by id").Check(testkit.Rows("3 c"))
+	tk.MustQuery("select * from t partition (p1,p3) order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "7 f"))
+	tk.MustQuery("select * from t partition (p1,p3,p0,p2) order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "3 c", "4 d", "7 f"))
+	tk.MustQuery("select * from t order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "3 c", "4 d", "7 f"))
+	tk.MustExec("delete from t partition (p0)")
+	tk.MustQuery("select * from t order by id").Check(testkit.Rows("<nil> <nil>", "1 a", "2 b", "4 d", "7 f"))
+	tk.MustExec("delete from t partition (p3,p2)")
+	tk.MustQuery("select * from t order by id").Check(testkit.Rows("1 a", "2 b"))
 }

--- a/go.mod
+++ b/go.mod
@@ -75,3 +75,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20201012092255-2cfb4a59c4d1

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/crazycs520/parser v0.0.0-20201012092255-2cfb4a59c4d1 h1:4HcDcvNnOGO2CGFYOqY2+F0iXSxsfpzKrAMHCCgJj6g=
+github.com/crazycs520/parser v0.0.0-20201012092255-2cfb4a59c4d1/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cznic/golex v0.0.0-20181122101858-9c343928389c/go.mod h1:+bmmJDNmKlhWNG+gwWCkaBoTy39Fs+bzRxVBzoTQbIc=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -187,38 +187,120 @@ func generateListPartitionExpr(ctx sessionctx.Context, pi *model.PartitionInfo,
 	columns []*expression.Column, names types.NameSlice) (*PartitionExpr, error) {
 	// The caller should assure partition info is not nil.
 	locateExprs := make([]expression.Expression, 0, len(pi.Definitions))
-	var buf bytes.Buffer
 	schema := expression.NewSchema(columns...)
-	partStr := pi.Expr
+	p := parser.New()
 	for _, def := range pi.Definitions {
-		fmt.Fprintf(&buf, "((%s) in (%s))", partStr, strings.Join(def.InValues, ","))
-		for _, value := range def.InValues {
-			exprs, err := expression.ParseSimpleExprsWithNames(ctx, value, schema, names)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			v, err := exprs[0].Eval(chunk.Row{})
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if v.IsNull() {
-				fmt.Fprintf(&buf, " or (%s) is null", partStr)
-			}
+		exprStr, err := generateListPartitionExprStr(ctx, pi, schema, names, &def, p)
+		if err != nil {
+			return nil, err
 		}
-
-		exprs, err := expression.ParseSimpleExprsWithNames(ctx, buf.String(), schema, names)
+		exprs, err := expression.ParseSimpleExprsWithNames(ctx, exprStr, schema, names)
 		if err != nil {
 			// If it got an error here, ddl may hang forever, so this error log is important.
-			logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", buf.String()), zap.Error(err))
+			logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", exprStr), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 		locateExprs = append(locateExprs, exprs[0])
-		buf.Reset()
 	}
 	ret := &PartitionExpr{
 		InValues: locateExprs,
 	}
 	return ret, nil
+}
+
+func generateListPartitionExprStr(ctx sessionctx.Context, pi *model.PartitionInfo,
+	schema *expression.Schema, names types.NameSlice, def *model.PartitionDefinition, p *parser.Parser) (string, error) {
+	var partStr string
+	if len(pi.Columns) == 0 {
+		partStr = pi.Expr
+	} else if len(pi.Columns) == 1 {
+		partStr = pi.Columns[0].L
+	} else {
+		return generateMultiListColumnsPartitionExprStr(ctx, pi, schema, names, def, p)
+	}
+	var buf, nullCondBuf bytes.Buffer
+	fmt.Fprintf(&buf, "(%s in (", partStr)
+	for i, vs := range def.InValues {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(vs[0])
+	}
+	buf.WriteString("))")
+	for _, vs := range def.InValues {
+		nullCondBuf.Reset()
+		hasNull := false
+		for i, value := range vs {
+			exprs, err := expression.ParseSimpleExprsWithNames(ctx, value, schema, names)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			v, err := exprs[0].Eval(chunk.Row{})
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			if i > 0 {
+				nullCondBuf.WriteString(" and ")
+			}
+			if v.IsNull() {
+				hasNull = true
+				fmt.Fprintf(&nullCondBuf, "%s is null", partStr)
+			} else {
+				fmt.Fprintf(&nullCondBuf, "%s = %s", partStr, value)
+			}
+		}
+		if hasNull {
+			fmt.Fprintf(&buf, " or (%s) ", nullCondBuf.String())
+		}
+	}
+	return buf.String(), nil
+}
+
+func generateMultiListColumnsPartitionExprStr(ctx sessionctx.Context, pi *model.PartitionInfo,
+	schema *expression.Schema, names types.NameSlice, def *model.PartitionDefinition, p *parser.Parser) (string, error) {
+	var buf, nullCondBuf bytes.Buffer
+	var partStr string
+	for i, col := range pi.Columns {
+		if i > 0 {
+			partStr += ","
+		}
+		partStr += col.L
+	}
+	fmt.Fprintf(&buf, "((%s) in (", partStr)
+	for i, vs := range def.InValues {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, "(%s)", strings.Join(vs, ","))
+	}
+	buf.WriteString("))")
+	for _, vs := range def.InValues {
+		nullCondBuf.Reset()
+		hasNull := false
+		for i, value := range vs {
+			exprs, err := expression.ParseSimpleExprsWithNames(ctx, value, schema, names)
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			v, err := exprs[0].Eval(chunk.Row{})
+			if err != nil {
+				return "", errors.Trace(err)
+			}
+			if i > 0 {
+				nullCondBuf.WriteString(" and ")
+			}
+			if v.IsNull() {
+				hasNull = true
+				fmt.Fprintf(&nullCondBuf, "%s is null", pi.Columns[i])
+			} else {
+				fmt.Fprintf(&nullCondBuf, "%s = %s", pi.Columns[i], value)
+			}
+		}
+		if hasNull {
+			fmt.Fprintf(&buf, " or (%s) ", nullCondBuf.String())
+		}
+	}
+	return buf.String(), nil
 }
 
 func generateHashPartitionExpr(ctx sessionctx.Context, pi *model.PartitionInfo,


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

related parser: https://github.com/pingcap/parser/pull/1047

Support `create`,`insert/delete/update/select`,`show create table` statement for `list partition` table.

Here is an example:

```sql
test> create table t (id int) partition by list  (id) (
   ->     partition p0 values in (1,2),
   ->     partition p1 values in (3,4),
   ->     partition p3 values in (5,null)
   ->     );
Query OK, 0 rows affected
Time: 0.006s
test> insert into t values (1),(3),(5),(null);
Query OK, 4 rows affected
Time: 0.004s
test> insert into t values (6);
(1526, 'Table has no partition for value 6')
test> select * from t partition (p0);
+----+
| id |
+----+
| 1  |
+----+
1 row in set
Time: 0.011s
test> delete from t partition (p0);
Query OK, 1 row affected
Time: 0.001s
test> select * from t;
+--------+
| id     |
+--------+
| 3      |
| 5      |
| <null> |
+--------+
3 rows in set
Time: 0.011s

```

**list columns partition**

```sql
test> create table t (id int, name varchar(10)) partition by list columns (id,name) (
   ->     partition p0 values in ((1,'a'),(2,'b')),
   ->         partition p1 values in ((3,'c'),(4,'d')),
   ->             partition p3 values in ((5,'e'),(null,null))
   ->             );
Query OK, 0 rows affected
Time: 0.008s
test> insert into t values (1, 'a'),(2,'b'),(null,null);
Query OK, 3 rows affected
Time: 0.004s
test> insert into t values (100,'z');
(1526, 'Table has no partition for value from column_list')
test> select * from t partition (p0);
+----+------+
| id | name |
+----+------+
| 1  | a    |
| 2  | b    |
+----+------+
2 rows in set
Time: 0.011s
test> delete from t partition (p0);
Query OK, 2 rows affected
Time: 0.001s
test> select * from t;
+--------+--------+
| id     | name   |
+--------+--------+
| <null> | <null> |
+--------+--------+
1 row in set
Time: 0.011s
test> show create table t;
+-------+-------------------------------------------------------------+
| Table | Create Table                                                |
+-------+-------------------------------------------------------------+
| t     | CREATE TABLE `t` (                                          |
|       |   `id` int(11) DEFAULT NULL,                                |
|       |   `name` varchar(10) DEFAULT NULL                           |
|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
|       | PARTITION BY LIST COLUMNS(id,name) (                        |
|       |   PARTITION `p0` VALUES IN ((1,"a"),(2,"b")),               |
|       |   PARTITION `p1` VALUES IN ((3,"c"),(4,"d")),               |
|       |   PARTITION `p3` VALUES IN ((5,"e"),(NULL,NULL))            |
|       | )                                                           |
+-------+-------------------------------------------------------------+
```

### What is changed and how it works?


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- Support list partition table



