### PR TITLE
display local/global in tidb_indexes

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -785,6 +785,7 @@ func (e *memtableRetriever) setDataFromIndexes(ctx sessionctx.Context, schemas [
 					"",            // INDEX_COMMENT
 					"NULL",        // Expression
 					0,             // INDEX_ID
+					"",
 				)
 				rows = append(rows, record)
 			}
@@ -808,6 +809,10 @@ func (e *memtableRetriever) setDataFromIndexes(ctx sessionctx.Context, schemas [
 						colName = "NULL"
 						expression = fmt.Sprintf("(%s)", tblCol.GeneratedExprString)
 					}
+					scope := "LOCAL"
+					if idxInfo.Global {
+						scope = "GLOBAL"
+					}
 					record := types.MakeDatums(
 						schema.Name.O,   // TABLE_SCHEMA
 						tb.Name.O,       // TABLE_NAME
@@ -819,6 +824,7 @@ func (e *memtableRetriever) setDataFromIndexes(ctx sessionctx.Context, schemas [
 						idxInfo.Comment, // INDEX_COMMENT
 						expression,      // Expression
 						idxInfo.ID,      // INDEX_ID
+						scope,
 					)
 					rows = append(rows, record)
 				}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -699,6 +699,7 @@ var tableTiDBIndexesCols = []columnInfo{
 	{name: "INDEX_COMMENT", tp: mysql.TypeVarchar, size: 2048},
 	{name: "Expression", tp: mysql.TypeVarchar, size: 64},
 	{name: "INDEX_ID", tp: mysql.TypeLonglong, size: 21},
+	{name: "Scope", tp: mysql.TypeVarchar, size: 64},
 }
 
 var slowQueryCols = []columnInfo{


### PR DESCRIPTION
```
MySQL [test]> create table t(a int, b int, c int, v int, unique key local_uk(a, b, c), key local_non_uk(v), unique key global_uk(c)) partition by hash(a + b) partitions 2;
Query OK, 0 rows affected (0.036 sec)

MySQL [test]> select * from information_schema.tidb_indexes where table_name = 't';
+--------------+------------+------------+--------------+--------------+-------------+----------+---------------+------------+----------+--------+
| TABLE_SCHEMA | TABLE_NAME | NON_UNIQUE | KEY_NAME     | SEQ_IN_INDEX | COLUMN_NAME | SUB_PART | INDEX_COMMENT | Expression | INDEX_ID | Scope  |
+--------------+------------+------------+--------------+--------------+-------------+----------+---------------+------------+----------+--------+
| test         | t          |          0 | local_uk     |            1 | a           |     NULL |               | NULL       |        1 | LOCAL  |
| test         | t          |          0 | local_uk     |            2 | b           |     NULL |               | NULL       |        1 | LOCAL  |
| test         | t          |          0 | local_uk     |            3 | c           |     NULL |               | NULL       |        1 | LOCAL  |
| test         | t          |          1 | local_non_uk |            1 | v           |     NULL |               | NULL       |        2 | LOCAL  |
| test         | t          |          0 | global_uk    |            1 | c           |     NULL |               | NULL       |        3 | GLOBAL |
+--------------+------------+------------+--------------+--------------+-------------+----------+---------------+------------+----------+--------+
5 rows in set (0.004 sec)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb7133/tidb/38)
<!-- Reviewable:end -->
