### PR TITLE
config: support clean audit log before max age

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -232,6 +232,8 @@ type Log struct {
 	EnableErrorStack nullableBool `toml:"enable-error-stack" json:"enable-error-stack"`
 	// File log config.
 	File logutil.FileLogConfig `toml:"file" json:"file"`
+	// AuditLogMaxHours max log keep hours
+	AuditLogMaxHours int `toml:"audit-log-max-hours" json:"audit-log-max-hours"`
 
 	EnableSlowLog       bool   `toml:"enable-slow-log" json:"enable-slow-log"`
 	SlowQueryFile       string `toml:"slow-query-file" json:"slow-query-file"`
@@ -573,6 +575,7 @@ var defaultConf = Config{
 		QueryLogMaxLen:      logutil.DefaultQueryLogMaxLen,
 		RecordPlanInSlowLog: logutil.DefaultRecordPlanInSlowLog,
 		EnableSlowLog:       logutil.DefaultTiDBEnableSlowLog,
+		AuditLogMaxHours:    0,
 	},
 	Status: Status{
 		ReportStatus:    true,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -138,6 +138,9 @@ expensive-threshold = 10000
 # Maximum query length recorded in log.
 query-log-max-len = 4096
 
+# Maximum log keep hours
+audit-log-max-hours = 0
+
 # File logging.
 [log.file]
 # Log file name.


### PR DESCRIPTION
works with https://github.com/pingcap/enterprise-plugin/commit/46b0771fbd31ffdb46b34b7ba9318f601285cdf1 add new config to control remove audit log from audit_log table

> log.audit-log-max-hours

Unit: hour, the default value is `0` which means "never remove"

it will remove the audit log records before "audit-log-max-hours" hours for the first audit log record in every 10 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb7133/tidb/39)
<!-- Reviewable:end -->
